### PR TITLE
Add better messages for string equality

### DIFF
--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -51,6 +51,14 @@ module TestHelpers =
         | [{ TestRunResult.result = TestResult.Failed _ }] -> ()
         | x -> failtestf "Should have failed, but was %A" x
 
+    let inline assertTestFailsWithMsg (msg : string) test =
+        let test = TestCase test
+        match evalSilent test with
+        | [{ TestRunResult.result = TestResult.Failed x }] when String.Equals(x.Replace("\n", ""),msg.Replace("\n", "")) -> ()
+        | [{ TestRunResult.result = TestResult.Failed x }] -> failtestf "Shold have failed with message: \"%s\" but failed with \"%s\"" msg x
+        | x -> failtestf "Should have failed, but was %A" x
+
+
     open FsCheck
 
     let genLimitedTimeSpan =

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -35,6 +35,26 @@ let tests =
       Expect.equal 4 (2+2) "2+2"
     }
 
+    testList "string comparison" [
+      test "string equal" {
+        Expect.equal "Test string" "Test string" "Test string"
+      }
+
+      test "fail - different length" {
+        let format = "Failing - string with different length"
+        let test () = Expect.equal "Test" "Test2" format
+        let msg = sprintf "%s. String actual shorter than expected, at pos %i for expected '%A'." format 4 '2'
+        assertTestFailsWithMsg msg test
+      }
+
+      test "fail - different content" {
+        let format = "Failing - string with different content"
+        let msg = sprintf "%s. String do not match at position %i. Expected: '%A', but got '%A'." format 3 't' '2'
+        let test () = Expect.equal "Tes2" "Test" format
+        assertTestFailsWithMsg msg test
+      }
+    ]
+
     testList "sumTestResults" [
       let sumTestResultsTests =
         [ { TestRunResult.name = ""; result = Passed; duration = TimeSpan.FromMinutes 2. }

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -44,14 +44,14 @@ let tests =
         let format = "Failing - string with different length"
         let test () = Expect.equal "Test" "Test2" format
         let msg = sprintf "%s. String actual shorter than expected, at pos %i for expected '%A'." format 4 '2'
-        assertTestFailsWithMsg msg test
+        assertTestFailsWithMsg msg (test, Normal)
       }
 
       test "fail - different content" {
         let format = "Failing - string with different content"
         let msg = sprintf "%s. String do not match at position %i. Expected: '%A', but got '%A'." format 3 't' '2'
         let test () = Expect.equal "Tes2" "Test" format
-        assertTestFailsWithMsg msg test
+        assertTestFailsWithMsg msg (test, Normal)
       }
     ]
 

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -123,9 +123,26 @@ let floatEqual actual expected epsilon format =
 
 /// Expects the two values to equal each other.
 let inline equal (actual : 'a) (expected : 'a) format =
-  if expected <> actual then
-    Tests.failtestf "%s. Actual value was %A but had expected it to be %A."
-                    format actual expected
+  match box actual, box expected with
+  | (:? string as a), (:? string as e) ->
+    use ai = a.GetEnumerator()
+    use ei = e.GetEnumerator()
+    let mutable i = 0
+    while ei.MoveNext() do
+      if ai.MoveNext() then
+        if ai.Current = ei.Current then ()
+        else
+          Tests.failtestf "%s. String do not match at position %i. Expected: '%A', but got '%A'."
+                            format i (ei.Current) (ai.Current)
+      else
+        Tests.failtestf "%s. String actual shorter than expected, at pos %i for expected '%A'."
+                        format i (ei.Current)
+      i <- i + 1
+  | _, _ ->
+    if actual <> expected then
+      Tests.failtestf "%s. Actual value was %A but had expected it to be %A." format actual expected
+
+
 
 /// Expects the two values not to equal each other.
 let notEqual (actual : 'a) (expected : 'a) format =


### PR DESCRIPTION
Right now it uses same algorithm as Streams and Sequences equality. 

Two questions:
1. Is it enough? Or should we scan whole string for differences instead of failing on 1st different character.

2. Should it be part of equals or moved to different function just as `streamsEqual` and `sequenceEqual`, or maybe other way round - merge `streamsEqual` and `sequenceEqual` into `equals` so there is smaller API surface for user.