### PR TITLE
Add parameter to list tests in console

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Tests",
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceRoot}/Expecto.Tests/bin/Release/Expecto.Tests.exe",
+            "args": ["--list-tests"],
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "compile",
+            "runtimeExecutable": null,
+            "env": {},
+            "externalConsole": false
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "rake",
+    "isShellCommand": true,
+    "args": [],
+    "showOutput": "always",
+    "tasks": [
+        {
+            "taskName": "compile",
+            "args": [
+                "compile"
+            ],
+            "isBuildCommand": true
+        }
+    ]
+}

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -214,12 +214,18 @@ let timeouts =
 
     testList "parse args" [
       testCase "default" <| fun _ ->
-        let opts, _ = ExpectoConfig.fillFromArgs defaultConfig [||]
+        let opts, isList = ExpectoConfig.fillFromArgs defaultConfig [||]
         opts.parallel ==? true
+        isList ==? false
 
       testCase "sequenced" <| fun _ ->
-        let opts, _ = ExpectoConfig.fillFromArgs defaultConfig [|"--sequenced"|]
+        let opts, isList = ExpectoConfig.fillFromArgs defaultConfig [|"--sequenced"|]
         opts.parallel ==? false
+        isList ==? false
+
+      testCase "list" <| fun _ ->
+        let _, isList = ExpectoConfig.fillFromArgs defaultConfig [|"--list-tests"|]
+        isList ==? true
     ]
 
     testList "transformations" [

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -214,11 +214,11 @@ let timeouts =
 
     testList "parse args" [
       testCase "default" <| fun _ ->
-        let opts = ExpectoConfig.fillFromArgs defaultConfig [||]
+        let opts, _ = ExpectoConfig.fillFromArgs defaultConfig [||]
         opts.parallel ==? true
 
       testCase "sequenced" <| fun _ ->
-        let opts = ExpectoConfig.fillFromArgs defaultConfig [|"--sequenced"|]
+        let opts, _ = ExpectoConfig.fillFromArgs defaultConfig [|"--sequenced"|]
         opts.parallel ==? false
     ]
 

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -663,9 +663,9 @@ module Tests =
     | Parallel
     | Debug
     | Filter of hiera:string
-    | FilterTestList of substring:string
-    | FilterTestCase of substring:string
-    | ListTests
+    | Filter_Test_List of substring:string
+    | Filter_Test_Case of substring:string
+    | List_Tests
 
     interface IArgParserTemplate with
       member s.Usage =
@@ -674,9 +674,9 @@ module Tests =
         | Parallel -> "Run all tests in parallel (default)."
         | Debug -> "Extra verbose printing. Useful to combine with --sequenced."
         | Filter _ -> "Filter the list of tests by a hierarchy that's slash (/) separated."
-        | FilterTestList _ -> "Filter the list of test lists by a substring."
-        | FilterTestCase _ -> "Filter the list of test cases by a substring."
-        | ListTests -> "Doesn't run tests, print out list of tests instead"
+        | Filter_Test_List _ -> "Filter the list of test lists by a substring."
+        | Filter_Test_Case _ -> "Filter the list of test cases by a substring."
+        | List_Tests -> "Doesn't run tests, print out list of tests instead"
 
   [<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
   module ExpectoConfig =
@@ -695,9 +695,9 @@ module Tests =
         | Parallel -> fun o -> { o with parallel = true }
         | Debug -> fun o -> { o with verbosity = LogLevel.Debug }
         | Filter _ -> fun o -> failwith "TODO: PRs much appreciated."
-        | FilterTestList _ -> fun o -> failwith "TODO: PRs much appreciated."
-        | FilterTestCase _ -> fun o -> failwith "TODO: PRs much appreciated."
-        | ListTests _ -> id
+        | Filter_Test_List _ -> fun o -> failwith "TODO: PRs much appreciated."
+        | Filter_Test_Case _ -> fun o -> failwith "TODO: PRs much appreciated."
+        | List_Tests -> id
 
 
 
@@ -708,15 +708,14 @@ module Tests =
             ignoreMissing = true,
             ignoreUnrecognized = true,
             raiseOnUsage = false)
-        let isList = parsed.Contains <@ ListTests @>
+        let isList = parsed.Contains <@ List_Tests @>
         (baseConfig, parsed.GetAllResults()) ||> Seq.fold (flip reduceKnown), isList
 
+  /// Prints out names of all tests for given test suite.
   let listTests test =
     test
     |> Test.toTestCodeList
     |> Seq.iter (fst3 >> printfn "%s")
-
-    0
 
   /// Runs tests with supplied options. Returns 0 if all tests passed, =
   /// otherwise 1
@@ -734,4 +733,4 @@ module Tests =
       | Some t -> t
       | None -> TestList ([], Normal)
     let config, isList = args |> ExpectoConfig.fillFromArgs config
-    if isList then listTests tests else runTests config tests
+    if isList then listTests tests; 0 else runTests config tests

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -665,6 +665,7 @@ module Tests =
     | Filter of hiera:string
     | FilterTestList of substring:string
     | FilterTestCase of substring:string
+    | ListTests
 
     interface IArgParserTemplate with
       member s.Usage =
@@ -675,6 +676,7 @@ module Tests =
         | Filter _ -> "Filter the list of tests by a hierarchy that's slash (/) separated."
         | FilterTestList _ -> "Filter the list of test lists by a substring."
         | FilterTestCase _ -> "Filter the list of test cases by a substring."
+        | ListTests -> "Doesn't run tests, print out list of tests instead"
 
   [<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
   module ExpectoConfig =
@@ -682,6 +684,7 @@ module Tests =
     /// Parses command-line arguments into a config. This allows you to
     /// override the config from the command line, rather than having
     /// to go into the compiled code to change how they are being run.
+    /// Also checks if tests should be run or only listed
     let fillFromArgs baseConfig =
       let parser = ArgumentParser.Create<CLIArguments>()
       let flip f a b = f b a
@@ -694,6 +697,9 @@ module Tests =
         | Filter _ -> fun o -> failwith "TODO: PRs much appreciated."
         | FilterTestList _ -> fun o -> failwith "TODO: PRs much appreciated."
         | FilterTestCase _ -> fun o -> failwith "TODO: PRs much appreciated."
+        | ListTests _ -> id
+
+
 
       fun (args: string[]) ->
         let parsed =
@@ -702,8 +708,15 @@ module Tests =
             ignoreMissing = true,
             ignoreUnrecognized = true,
             raiseOnUsage = false)
+        let isList = parsed.Contains <@ ListTests @>
+        (baseConfig, parsed.GetAllResults()) ||> Seq.fold (flip reduceKnown), isList
 
-        (baseConfig, parsed.GetAllResults()) ||> Seq.fold (flip reduceKnown)
+  let listTests test =
+    test
+    |> Test.toTestCodeList
+    |> Seq.iter (fst3 >> printfn "%s")
+
+    0
 
   /// Runs tests with supplied options. Returns 0 if all tests passed, =
   /// otherwise 1
@@ -720,5 +733,5 @@ module Tests =
       match testFromAssembly (Assembly.GetEntryAssembly()) with
       | Some t -> t
       | None -> TestList ([], Normal)
-    let config = args |> ExpectoConfig.fillFromArgs config
-    runTests config tests
+    let config, isList = args |> ExpectoConfig.fillFromArgs config
+    if isList then listTests tests else runTests config tests


### PR DESCRIPTION
It'll be useful for Ionide (and maybe other editors) integration.

PR also adds VSCode configuration letting build and debug `Expecto.Tests` project.