### PR TITLE
Add run parameter

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -230,25 +230,24 @@ let timeouts =
       testList "filtering" [
         let dummy =
           TestList ([
-                      testCase "a" ignore
-                      testCase "a_x" ignore
-                      testCase "b" ignore
-                      testList "c" [
-                        testCase "d" ignore
-                        testCase "e" ignore
-                        testList "f" [
-                          testCase "g" ignore
-                          testCase "h" ignore
-                        ]
+                    testCase "a" ignore
+                    testCase "a_x" ignore
+                    testCase "b" ignore
+                    testList "c" [
+                      testCase "d" ignore
+                      testCase "e" ignore
+                      testList "f" [
+                        testCase "g" ignore
+                        testCase "h" ignore
                       ]
-                    ], Normal)
+                    ]
+                  ], Normal)
 
 
         yield testCase "filter" <| fun _ ->
           let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter c"|]
-          let filtered = dummy |> opts.filter |> Test.toTestCodeList |> Seq.toList
-          printfn "%A" filtered
-          filtered.Length ==? 4
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 4
 
         yield testCase "filter deep" <| fun _ ->
           let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter c/f"|]

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -226,6 +226,68 @@ let timeouts =
       testCase "list" <| fun _ ->
         let _, isList = ExpectoConfig.fillFromArgs defaultConfig [|"--list-tests"|]
         isList ==? true
+
+      testList "filtering" [
+        let dummy =
+          TestList ([
+                      testCase "a" ignore
+                      testCase "a_x" ignore
+                      testCase "b" ignore
+                      testList "c" [
+                        testCase "d" ignore
+                        testCase "e" ignore
+                        testList "f" [
+                          testCase "g" ignore
+                          testCase "h" ignore
+                        ]
+                      ]
+                    ], Normal)
+
+
+        yield testCase "filter" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter c"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList |> Seq.toList
+          printfn "%A" filtered
+          filtered.Length ==? 4
+
+        yield testCase "filter deep" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter c/f"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 2
+
+        yield testCase "filter wrong" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter f"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 0
+
+        yield testCase "filter test list" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-list f"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 2
+
+        yield testCase "filter test list wrong" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-list x"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 0
+
+        yield testCase "filter test case" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-case a"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 2
+
+        yield testCase "filter test case wrong" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-case y"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 0
+
+        yield testCase "run" <| fun _ ->
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--run a c/d c/f/h"|]
+          let filtered = dummy |> opts.filter |> Test.toTestCodeList
+          filtered |> Seq.length ==? 3
+
+
+      ]
+
     ]
 
     testList "transformations" [

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -154,14 +154,15 @@ let timeouts =
 
     testList "Test filter" [
       let tests =
-        TestList ([
-                    testCase "a" ignore
-                    testCase "b" ignore
-                    testList "c" [
-                      testCase "d" ignore
-                      testCase "e" ignore
-                    ]
-                  ], Normal)
+        TestList (
+          [
+            testCase "a" ignore
+            testCase "b" ignore
+            testList "c" [
+              testCase "d" ignore
+              testCase "e" ignore
+            ]
+          ], Normal)
       yield testCase "with one testcase" <| fun _ ->
         let t = Test.filter ((=) "a") tests |> Test.toTestCodeList |> Seq.toList
         t.Length ==? 1 // same as assertEqual "" 1 t.Length
@@ -229,19 +230,20 @@ let timeouts =
 
       testList "filtering" [
         let dummy =
-          TestList ([
-                    testCase "a" ignore
-                    testCase "a_x" ignore
-                    testCase "b" ignore
-                    testList "c" [
-                      testCase "d" ignore
-                      testCase "e" ignore
-                      testList "f" [
-                        testCase "g" ignore
-                        testCase "h" ignore
-                      ]
-                    ]
-                  ], Normal)
+          TestList (
+            [
+              testCase "a" ignore
+              testCase "a_x" ignore
+              testCase "b" ignore
+              testList "c" [
+                testCase "d" ignore
+                testCase "e" ignore
+                testList "f" [
+                  testCase "g" ignore
+                  testCase "h" ignore
+                ]
+              ]
+            ], Normal)
 
 
         yield testCase "filter" <| fun _ ->

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -247,42 +247,42 @@ let timeouts =
 
 
         yield testCase "filter" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter c"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter"; "c"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 4
 
         yield testCase "filter deep" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter c/f"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter"; "c/f"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 2
 
         yield testCase "filter wrong" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter f"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter"; "f"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 0
 
         yield testCase "filter test list" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-list f"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-list"; "f"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 2
 
         yield testCase "filter test list wrong" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-list x"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-list"; "x"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 0
 
         yield testCase "filter test case" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-case a"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-case"; "a"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 2
 
         yield testCase "filter test case wrong" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-case y"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--filter-test-case"; "y"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 0
 
         yield testCase "run" <| fun _ ->
-          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--run a c/d c/f/h"|]
+          let opts, _ =  ExpectoConfig.fillFromArgs defaultConfig [|"--run"; "a"; "c/d"; "c/f/h"|]
           let filtered = dummy |> opts.filter |> Test.toTestCodeList
           filtered |> Seq.length ==? 3
 

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -665,6 +665,7 @@ module Tests =
     | Filter of hiera:string
     | Filter_Test_List of substring:string
     | Filter_Test_Case of substring:string
+    | Run of tests:string list
     | List_Tests
 
     interface IArgParserTemplate with
@@ -676,6 +677,7 @@ module Tests =
         | Filter _ -> "Filter the list of tests by a hierarchy that's slash (/) separated."
         | Filter_Test_List _ -> "Filter the list of test lists by a substring."
         | Filter_Test_Case _ -> "Filter the list of test cases by a substring."
+        | Run _ -> "Run only provided tests"
         | List_Tests -> "Doesn't run tests, print out list of tests instead"
 
   [<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
@@ -712,6 +714,7 @@ module Tests =
         | Filter hiera -> fun o -> {o with filter = Test.filter (fun s -> s.StartsWith hiera )}
         | Filter_Test_List name ->  fun o -> {o with filter = Test.filter (fun s -> s |> getTestList |> Array.exists(fun s -> s.Contains name )) }
         | Filter_Test_Case name ->  fun o -> {o with filter = Test.filter (fun s -> s |> getTastCase |> fun s -> s.Contains name )}
+        | Run tests -> fun o -> {o with filter = Test.filter (fun s -> tests |> List.exists ((=) s) )}
         | List_Tests -> id
 
 


### PR DESCRIPTION
Add parameter which allows user to specify exact list of tests to run.

Current behavior:
```
λ .\Expecto.Tests\bin\Release\Expecto.Tests.exe --run all/basic "all/using computation expression" "all/sumTestResults/passed"
[16:33:57 INF] EXPECTO? Running tests...
[16:33:57 INF] EXPECTO! 3 tests run in 00:00:00.0476590 - 3 passed, 0 ignored, 0 failed, 0 errored.
```