### PR TITLE
Add more assertions

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -366,6 +366,24 @@ let timeouts =
           let test () = Expect.stringContains "hello world" "a" "Deliberately failing"
           assertTestFails (test, Normal)
       ]
+
+      testList "string starts" [
+        testCase "pass" <| fun _ ->
+          Expect.stringStarts "hello world" "hello" "String actually starts"
+
+        testCase "fail" <| fun _ ->
+          let test () = Expect.stringStarts "hello world" "a" "Deliberately failing"
+          assertTestFails (test, Normal)
+      ]
+
+      testList "string ends" [
+        testCase "pass" <| fun _ ->
+          Expect.stringEnds "hello world" "world" "String actually ends"
+
+        testCase "fail" <| fun _ ->
+          let test () = Expect.stringEnds "hello world" "a" "Deliberately failing"
+          assertTestFails (test, Normal)
+      ]
     ]
 
     testList "computation expression" [

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -414,6 +414,19 @@ let timeouts =
           assertTestFails (test, Normal)
       ]
 
+      testList "sequence starts" [
+        testCase "pass" <| fun _ ->
+          Expect.sequenceStarts [1;2;3] [1;2] "Sequences actually starts"
+
+        testCase "fail - different" <| fun _ ->
+          let test () = Expect.sequenceStarts [1;2;3] [2] "Deliberately failing"
+          assertTestFails (test, Normal)
+
+        testCase "fail - subject shorter" <| fun _ ->
+          let test () = Expect.sequenceStarts [1] [1;2;3] "Deliberately failing"
+          assertTestFails (test, Normal)
+      ]
+
     ]
 
     testList "computation expression" [

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -40,10 +40,17 @@ let tests =
         Expect.equal "Test string" "Test string" "Test string"
       }
 
-      test "fail - different length" {
+      test "fail - different length, shorter" {
         let format = "Failing - string with different length"
         let test () = Expect.equal "Test" "Test2" format
         let msg = sprintf "%s. String actual shorter than expected, at pos %i for expected '%A'." format 4 '2'
+        assertTestFailsWithMsg msg (test, Normal)
+      }
+
+      test "fail - different length, longer" {
+        let format = "Failing - string with different length"
+        let test () = Expect.equal "Test2" "Test" format
+        let msg = sprintf "%s. String actual longer than expected, at pos %i found '%A'." format 4 '2'
         assertTestFailsWithMsg msg (test, Normal)
       }
 
@@ -398,8 +405,12 @@ let timeouts =
         testCase "pass" <| fun _ ->
           Expect.sequenceEqual [1;2;3] [1;2;3] "Sequences actually equal"
 
-        testCase "fail" <| fun _ ->
+        testCase "fail - longer" <| fun _ ->
           let test () = Expect.sequenceEqual [1;2;3] [1] "Deliberately failing"
+          assertTestFails (test, Normal)
+
+        testCase "fail - shorter" <| fun _ ->
+          let test () = Expect.sequenceEqual [1] [1;2;3] "Deliberately failing"
           assertTestFails (test, Normal)
       ]
 

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -384,6 +384,15 @@ let timeouts =
           let test () = Expect.stringEnds "hello world" "a" "Deliberately failing"
           assertTestFails (test, Normal)
       ]
+
+      testList "string has length" [
+        testCase "pass" <| fun _ ->
+          Expect.stringHasLength "hello" 5 "String actually has length"
+
+        testCase "fail" <| fun _ ->
+          let test () = Expect.stringHasLength "hello world" 5 "Deliberately failing"
+          assertTestFails (test, Normal)
+      ]
     ]
 
     testList "computation expression" [

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -427,6 +427,24 @@ let timeouts =
           assertTestFails (test, Normal)
       ]
 
+      testList "sequence ascending" [
+        testCase "pass" <| fun _ ->
+          Expect.isAscending [1;2;3] "Sequences actually ascending"
+
+        testCase "fail " <| fun _ ->
+          let test () = Expect.isAscending [1;3;2] "Deliberately failing"
+          assertTestFails (test, Normal)
+      ]
+
+      testList "sequence descending" [
+        testCase "pass" <| fun _ ->
+          Expect.isDescending [3;2;1] "Sequences actually descending"
+
+        testCase "fail " <| fun _ ->
+          let test () = Expect.isDescending [3;1;2] "Deliberately failing"
+          assertTestFails (test, Normal)
+      ]
+
     ]
 
     testList "computation expression" [

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -393,6 +393,16 @@ let timeouts =
           let test () = Expect.stringHasLength "hello world" 5 "Deliberately failing"
           assertTestFails (test, Normal)
       ]
+
+      testList "sequence equal" [
+        testCase "pass" <| fun _ ->
+          Expect.sequenceEqual [1;2;3] [1;2;3] "Sequences actually equal"
+
+        testCase "fail" <| fun _ ->
+          let test () = Expect.sequenceEqual [1;2;3] [1] "Deliberately failing"
+          assertTestFails (test, Normal)
+      ]
+
     ]
 
     testList "computation expression" [

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -201,6 +201,14 @@ let stringStarts (subject : string) (prefix : string) format =
     Tests.failtestf "%s. Expected subject string '%s' to start with '%s'."
                     format subject prefix
 
+/// Expect the string `subject` to start with `suffix`. If it does not
+/// then fail with `format` as an error message together with a description
+/// of `subject` and `suffix`.
+let stringEnds (subject : string) (suffix : string) format =
+  if not (subject.EndsWith suffix) then
+    Tests.failtestf "%s. Expected subject string '%s' to end with '%s'."
+                    format subject suffix
+
 
 /// Expect the streams to byte-wise equal.
 let streamsEqual (s1 : IO.Stream) (s2 : IO.Stream) format =

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -237,7 +237,7 @@ let stringStarts (subject : string) (prefix : string) format =
     Tests.failtestf "%s. Expected subject string '%s' to start with '%s'."
                     format subject prefix
 
-/// Expect the string `subject` to start with `suffix`. If it does not
+/// Expect the string `subject` to end with `suffix`. If it does not
 /// then fail with `format` as an error message together with a description
 /// of `subject` and `suffix`.
 let stringEnds (subject : string) (suffix : string) format =

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -191,6 +191,24 @@ let sequenceEqual (actual : _ seq) (expected : _ seq) format =
     Tests.failtestf "%s. Sequence actual longer than expected, at pos %i found item %A."
                       format i (ai.Current)
 
+/// Expect the string `subject` to start with `prefix`. If it does not
+/// then fail with `format` as an error message together with a description
+/// of `subject` and `prefix`.
+let sequenceStarts (subject : _ seq) (prefix : _ seq) format =
+  use si = subject.GetEnumerator()
+  use pi = prefix.GetEnumerator()
+  let mutable i = 0
+  while pi.MoveNext() do
+    if si.MoveNext() then
+      if si.Current = pi.Current then ()
+      else
+        Tests.failtestf "%s. Sequence do not match at position %i. Expected: %A, but got %A."
+                           format i (pi.Current) (si.Current)
+    else
+      Tests.failtestf "%s. Sequence actual shorter than expected, at pos %i for expected item %A."
+                      format i (pi.Current)
+    i <- i + 1
+
 
 /// Expect the string `subject` to contain `substring` as part of itself.
 /// If it does not, then fail with `format` and `subject` and `substring`

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -138,6 +138,9 @@ let inline equal (actual : 'a) (expected : 'a) format =
         Tests.failtestf "%s. String actual shorter than expected, at pos %i for expected '%A'."
                         format i (ei.Current)
       i <- i + 1
+    if ai.MoveNext() then
+      Tests.failtestf "%s. String actual longer than expected, at pos %i found '%A'."
+                      format i (ai.Current)
   | _, _ ->
     if actual <> expected then
       Tests.failtestf "%s. Actual value was %A but had expected it to be %A." format actual expected
@@ -184,7 +187,9 @@ let sequenceEqual (actual : _ seq) (expected : _ seq) format =
       Tests.failtestf "%s. Sequence actual shorter than expected, at pos %i for expected item %A."
                       format i (ei.Current)
     i <- i + 1
-
+  if ai.MoveNext() then
+    Tests.failtestf "%s. Sequence actual longer than expected, at pos %i found item %A."
+                      format i (ai.Current)
 
 
 /// Expect the string `subject` to contain `substring` as part of itself.

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -191,7 +191,7 @@ let sequenceEqual (actual : _ seq) (expected : _ seq) format =
     Tests.failtestf "%s. Sequence actual longer than expected, at pos %i found item %A."
                       format i (ai.Current)
 
-/// Expect the string `subject` to start with `prefix`. If it does not
+/// Expect the sequence `subject` to start with `prefix`. If it does not
 /// then fail with `format` as an error message together with a description
 /// of `subject` and `prefix`.
 let sequenceStarts (subject : _ seq) (prefix : _ seq) format =
@@ -209,6 +209,17 @@ let sequenceStarts (subject : _ seq) (prefix : _ seq) format =
                       format i (pi.Current)
     i <- i + 1
 
+/// Expect the sequence `subject` to be ascending. If it does not
+/// then fail with `format` as an error message.
+let isAscending (subject : _ seq) format =
+  if not (subject |> Seq.windowed 2 |> Seq.forall (fun s -> s.[1] >= s.[0])) then
+    Tests.failtestf "%s. Sequence is not ascending" format
+
+/// Expect the sequence `subject` to be descending. If it does not
+/// then fail with `format` as an error message.
+let isDescending  (subject : _ seq) format =
+  if not (subject |> Seq.windowed 2 |> Seq.forall (fun s -> s.[1] <= s.[0])) then
+    Tests.failtestf "%s. Sequence is not descending" format
 
 /// Expect the string `subject` to contain `substring` as part of itself.
 /// If it does not, then fail with `format` and `subject` and `substring`

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -185,6 +185,8 @@ let sequenceEqual (actual : _ seq) (expected : _ seq) format =
                       format i (ei.Current)
     i <- i + 1
 
+
+
 /// Expect the string `subject` to contain `substring` as part of itself.
 /// If it does not, then fail with `format` and `subject` and `substring`
 /// as part of the error message.
@@ -208,6 +210,14 @@ let stringEnds (subject : string) (suffix : string) format =
   if not (subject.EndsWith suffix) then
     Tests.failtestf "%s. Expected subject string '%s' to end with '%s'."
                     format subject suffix
+
+/// Expect the string `subject` to have length equals `length`. If it does not
+/// then fail with `format` as an error message together with a description
+/// of `subject` and `length`.
+let stringHasLength (subject : string) (length : int) format =
+  if subject.Length <> length then
+    Tests.failtestf "%s. Expected subject string '%s' to have length '%d'."
+                    format subject length
 
 
 /// Expect the streams to byte-wise equal.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ integrationTests // from MyLib.Tests
 
 ### Focusing tests
 
-It is often convenient, when developing to be able to run a subset of specs. 
+It is often convenient, when developing to be able to run a subset of specs.
 Expecto allows you to focus specific test cases or tests list by putting `f` before *testCase* or *testList* or `F` before attribute *Tests*(when reflection tests discovery is used).
 
 ```fsharp
@@ -124,7 +124,7 @@ open Expecto
 [<FTests>]
 let someFocusedTest = testCase "will run" <| fun _ -> Expect.equal (2+2) 4 "2+2"
 [<Tests>]
-let someUnfocusedTest = test "skipped" { Expect.equal (2+2) 1 "2+2?" } 
+let someUnfocusedTest = test "skipped" { Expect.equal (2+2) 1 "2+2?" }
 ```
 
 or
@@ -133,7 +133,7 @@ or
 open Expecto
 
 [<Tests>]
-let focusedTests = 
+let focusedTests =
   testList "unfocused list" [
     ftestList "focused list" [
       testCase "will run" <| fun _ -> Expect.equal (2+2) 4 "2+2"
@@ -148,7 +148,7 @@ let focusedTests =
     ]
     testCase "skipped" <| fun _ -> Expect.equal (2+2) 1 "2+2?"
   ]
-``` 
+```
 
 ### Pending tests
 
@@ -159,7 +159,7 @@ You do this by adding a `p` before *testCase* or *testList* or `P` before *Tests
 open Expecto
 
 [<PTests>]
-let skippedTestFromReflectionDiscovery = testCase "skipped" <| fun _ -> 
+let skippedTestFromReflectionDiscovery = testCase "skipped" <| fun _ ->
     Expect.equal (2+2) 4 "2+2"
 
 [<Tests>]
@@ -177,7 +177,7 @@ let myTests =
       ftestCase "skipped" <| fun _ -> Expect.equal (2+2) 1 "2+2?"
     ]
   ]
-```  
+```
 
 ## Expectations
 
@@ -205,12 +205,25 @@ This module is your main entry-point when asserting.
  - `isFalse`
  - `isTrue`
  - `sequenceEqual`
+ - `sequenceStarts` - Expect the sequence `subject` to start with `prefix`. If it does not
+   then fail with `format` as an error message together with a description
+   of `subject` and `prefix`.
+ - `isAscending` - Expect the sequence `subject` to be ascending. If it does not
+   then fail with `format` as an error message.
+ - `isDescending` - Expect the sequence `subject` to be descending. If it does not
+   then fail with `format` as an error message.
  - `stringContains` – Expect the string `subject` to contain `substring` as part
    of itself.  If it does not, then fail with `format` and `subject` and
    `substring` as part of the error message.
  - `stringStarts` – Expect the string `subject` to start with `prefix` and if it
    does not then fail with `format` as an error message together with a
    description of `subject` and `prefix`.
+ - `stringEnds` - Expect the string `subject` to end with `suffix`. If it does not
+   then fail with `format` as an error message together with a description
+   of `subject` and `suffix`.
+ - `stringHasLength` - Expect the string `subject` to have length equals `length`. If it does not
+   then fail with `format` as an error message together with a description
+   of `subject` and `length`.
  - `contains : 'a seq -> 'a -> string -> unit` – Expect the sequence to contain the item.
  - `streamsEqual` – Expect the streams to be byte-wise identical.
 

--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ Parameters available if you use `Tests.runTestsInAssembly defaultConfig argv` in
  - `--debug`: Extra verbose output for your tests.
  - `--sequenced`: Run all tests in sequence.
  - `--parallel`: (default) Run all tests in parallel.
- - `--filter <hiera>`: Filter a specific hierarchy to run (**TBD**).
- - `--filter-test-list <substring>`: Filter a specific test list to run
-   (**TBD**).
- - `--filter-test-case <substring>`: Filter a specific test case to run
-   (**TBD**).
+ - `--filter <hiera>`: Filter a specific hierarchy to run.
+ - `--filter-test-list <substring>`: Filter a specific test list to run.
+ - `--filter-test-case <substring>`: Filter a specific test case to run.
+ - `--run [<tests1> <test2> ...]`: Run only provided tests.
+ - `--list-tests`: Doesn't run tests, print out list of tests instead.
 
 ### The config
 


### PR DESCRIPTION
1. Adds following assertions:
* `stringEnds`
* `strignHasLength`
* `sequenceStarts`
* `isAscending`
* `isDescending`

2. Fixes bug in string and sequence equals when actual was longer than expected

3. Adds to readme new assertions, and changes in parameters done as part of previous PRs.  