### PR TITLE
Add summary

### DIFF
--- a/Expecto.Tests/FocusedTests.fs
+++ b/Expecto.Tests/FocusedTests.fs
@@ -66,12 +66,12 @@ let all =
   testList "all focused tests" [
     testCase "pending" <| fun _ ->
         let result = evalSilent pendingTests |> synth
-        result.passed ==? 2
-        result.ignored ==? 5
+        result.passed.Length ==? 2
+        result.ignored.Length ==? 5
     testCase "focused" <| fun _ ->
         let result = evalSilent focusedTests |> synth
-        result.passed ==? 11
-        result.ignored ==? 19
+        result.passed.Length ==? 11
+        result.ignored.Length ==? 19
 ]
 
 [<PTests>]

--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -70,13 +70,13 @@ module TestHelpers =
     let genTestResultCounts =
         lazy (
             gen {
-                let! passed = Arb.generate<int>
-                let! ignored = Arb.generate<int>
-                let! failed = Arb.generate<int>
-                let! errored = Arb.generate<int>
+                let! passed = Arb.generate<string list>
+                let! ignored = Arb.generate<string list>
+                let! failed = Arb.generate<string list>
+                let! errored = Arb.generate<string list>
                 let! duration = genLimitedTimeSpan.Value
                 return
-                  { TestResultCounts.passed = passed
+                  { TestResultSummary.passed = passed
                     ignored  = ignored
                     failed   = failed
                     errored  = errored
@@ -84,7 +84,7 @@ module TestHelpers =
             }
         )
 
-    let shrinkTestResultCounts (c: TestResultCounts) : TestResultCounts seq =
+    let shrinkTestResultCounts (c: TestResultSummary) : TestResultSummary seq =
         seq {
             for passed in Arb.shrink c.passed do
             for ignored in Arb.shrink c.ignored do
@@ -92,7 +92,7 @@ module TestHelpers =
             for errored in Arb.shrink c.errored do
             for duration in Arb.shrink c.duration ->
             {
-                TestResultCounts.passed = passed
+                TestResultSummary.passed = passed
                 ignored = ignored
                 failed = failed
                 errored = errored

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -73,11 +73,11 @@ let tests =
         ]
       let r = lazy sumTestResults sumTestResultsTests
       yield testCase "passed" <| fun _ ->
-          r.Value.passed ==? 3
+          r.Value.passed.Length ==? 3
       yield testCase "failed" <| fun _ ->
-          r.Value.failed ==? 2
+          r.Value.failed.Length ==? 2
       yield testCase "exn" <| fun _ ->
-          r.Value.errored ==? 1
+          r.Value.errored.Length ==? 1
       yield testCase "duration" <| fun _ ->
           r.Value.duration ==? TimeSpan.FromMinutes 27.
     ]
@@ -91,18 +91,18 @@ let tests =
                       let r = a + b
                       f a b r)
         yield testResultCountsSum "Passed" <|
-          fun a b r -> r.passed = a.passed + b.passed
+          fun a b r -> r.passed = a.passed @ b.passed
         yield testResultCountsSum "Ignored" <|
-          fun a b r -> r.ignored = a.ignored + b.ignored
+          fun a b r -> r.ignored = a.ignored @ b.ignored
         yield testResultCountsSum "Failed" <|
-          fun a b r -> r.failed = a.failed + b.failed
+          fun a b r -> r.failed = a.failed @ b.failed
         yield testResultCountsSum "Errored" <|
-          fun a b r -> r.errored = a.errored + b.errored
+          fun a b r -> r.errored = a.errored @ b.errored
         yield testResultCountsSum "Time" <|
           fun a b r -> r.duration = a.duration + b.duration
       ]
       testCase "ToString" <| fun _ ->
-        let c1 = { passed = 1; ignored = 5; failed = 2; errored = 3; duration = TimeSpan.FromSeconds 20. }
+        let c1 = { passed = [""]; ignored = [""; ""; ""; ""; ""]; failed = [""; ""]; errored = [""; ""; ""]; duration = TimeSpan.FromSeconds 20. }
         c1.ToString() ==? "6 tests run: 1 passed, 5 ignored, 2 failed, 3 errored (00:00:20)\n"
     ]
 
@@ -188,11 +188,11 @@ let timeouts =
       testCase "fail" <| fun _ ->
         let test = TestCase(Test.timeout 10 (fun _ -> Thread.Sleep 100), Normal)
         let result = evalSilent test |> sumTestResults
-        result.failed ==? 1
+        result.failed.Length ==? 1
       testCase "pass" <| fun _ ->
         let test = TestCase(Test.timeout 1000 ignore, Normal)
         let result = evalSilent test |> sumTestResults
-        result.passed ==? 1
+        result.passed.Length ==? 1
     ]
 
     testList "Reflection" [

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Parameters available if you use `Tests.runTestsInAssembly defaultConfig argv` in
  - `--filter-test-case <substring>`: Filter a specific test case to run.
  - `--run [<tests1> <test2> ...]`: Run only provided tests.
  - `--list-tests`: Doesn't run tests, print out list of tests instead.
+ - `--summary`: Prints out summary after all tests are finished
 
 ### The config
 


### PR DESCRIPTION
Adds option to print out additional summary after all tests are run if `--summary` parameter is provided.

```
λ .\Expecto.Tests\bin\Release\Expecto.Tests.exe --filter-test-list expectations --summary                             
[23:08:49 INF] EXPECTO? Running tests...                                                                              

...
                                                                                                                      
[23:08:49 INF] EXPECTO! 23 tests run in 00:00:00.1124037 - 23 passed, 0 ignored, 0 failed, 0 errored.                 
[23:08:49 INF] EXPECTO?! Summary...                                                                                   
Passed:                                                                                                               
        timeout/expectations/raise/pass                                                                               
        timeout/expectations/notEqual/pass                                                                            
        timeout/expectations/string starts/fail                                                                       
        timeout/expectations/string ends/pass                                                                         
        timeout/expectations/sequence descending/pass                                                                 
        timeout/expectations/string has length/pass                                                                   
        timeout/expectations/sequence equal/pass                                                                      
        timeout/expectations/sequence equal/fail - longer                                                             
        timeout/expectations/sequence ascending/pass                                                                  
        timeout/expectations/raise/fail with incorrect exception                                                      
        timeout/expectations/string has length/fail                                                                   
        timeout/expectations/sequence descending/fail                                                                 
        timeout/expectations/notEqual/fail                                                                            
        timeout/expectations/sequence equal/fail - shorter                                                            
        timeout/expectations/raise/fail with no exception                                                             
        timeout/expectations/sequence starts/pass                                                                     
        timeout/expectations/sequence starts/fail - subject shorter                                                   
        timeout/expectations/string contain/pass                                                                      
        timeout/expectations/string starts/pass                                                                       
        timeout/expectations/string ends/fail                                                                         
        timeout/expectations/sequence ascending/fail                                                                  
        timeout/expectations/string contain/fail                                                                      
        timeout/expectations/sequence starts/fail - different                                                         
Ignored:                                                                                                              
                                                                                                                      
Failed:                                                                                                               
                                                                                                                      
Errored:                                                                                                              
                                                                                                                      
```