### PR TITLE
Fix sumTestResults

### DIFF
--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -2,6 +2,7 @@
 #nowarn "44"
 
 open System
+open System.Text.RegularExpressions
 open FSharpx
 
 module Seq =
@@ -52,9 +53,11 @@ module TestHelpers =
         | x -> failtestf "Should have failed, but was %A" x
 
     let inline assertTestFailsWithMsg (msg : string) test =
+        let normalize str = Regex.Replace(msg, @"\s", "")
+
         let test = TestCase test
         match evalSilent test with
-        | [{ TestRunResult.result = TestResult.Failed x }] when String.Equals(x.Replace("\n", ""),msg.Replace("\n", "")) -> ()
+        | [{ TestRunResult.result = TestResult.Failed x }] when String.Equals(normalize x, normalize msg) -> ()
         | [{ TestRunResult.result = TestResult.Failed x }] -> failtestf "Shold have failed with message: \"%s\" but failed with \"%s\"" msg x
         | x -> failtestf "Should have failed, but was %A" x
 

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -303,13 +303,13 @@ module Impl =
   let sumTestResults (results: #seq<TestRunResult>) =
     let counts =
       results
-      |> Seq.groupBy (fun r -> r.result )
+      |> Seq.groupBy (fun r -> TestResult.tag r.result )
       |> dict
 
     let get result =
-        match counts.TryGetValue result with
-        | true, v -> v |> Seq.map (fun r -> r.name) |> Seq.toList
-        | _ -> List.empty
+      match counts.TryGetValue (TestResult.tag result) with
+      | true, v -> v |> Seq.map (fun r -> r.name) |> Seq.toList
+      | _ -> List.empty
 
     { passed   = get TestResult.Passed
       ignored  = get (TestResult.Ignored "")

--- a/Rakefile
+++ b/Rakefile
@@ -72,8 +72,7 @@ end
 
 namespace :tests do
   task :unit do
-    system "Expecto.Tests/bin/#{Configuration}/Expecto.Tests.exe",
-      clr_command: true
+    system "Expecto.Tests/bin/#{Configuration}/Expecto.Tests.exe", '--summary', clr_command: true
   end
 end
 


### PR DESCRIPTION
Fixes summary aggregation. Which should fix both #24 and #23.

Current output for Expecto.Sample:
```
λ .\Expecto.Sample.exe --summary
[16:22:44 INF] EXPECTO? Running tests...
[16:22:44 ERR] samples/should fail failed in 00:00:00.0002488.
I should fail because the subject is false.
  D:\Programowanie\Projekty\expecto\Expecto.Sample\Expecto.Sample.fs(14,1): Expecto.Sample.tests@14-2.Invoke(Unit _arg2)

[16:22:44 INF] EXPECTO! 2 tests run in 00:00:00.0556704 - 1 passed, 0 ignored, 1 failed, 0 errored.
[16:22:44 INF] EXPECTO?! Summary...
Passed:
        samples/universe exists
Ignored:

Failed:
        samples/should fail
Errored:

λ $lastExitCode
1
```

Sorry for introducing this bug in first place :-(