### PR TITLE
Add containsAll method to expecto

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -431,6 +431,52 @@ let timeouts =
           assertTestFails (test, Normal)
       ]
 
+      testList "contains all comparison" [
+        test "sequence contains all" {
+          Expect.containsAll [|21;37|] [|21;37|] "test sequence"
+        }
+
+        test "sequence contains all in different order" {
+          Expect.containsAll [|21;37|] [|37;21|] "test sequence"
+        }
+
+        test "fail - actual sequence contains more elements" {
+          let format = "Failing - sequence does not contain proper elements"
+          let fstSeq = [|2;1;3|]
+          let sndSeq = [|1;3|]
+          let test () = Expect.containsAll fstSeq sndSeq format
+          let msg = sprintf "%s.
+              Sequence does not contains all elements
+              Should contains:
+              %A
+              But contains:
+              %A
+              Missing values:
+              %A" 
+                      format fstSeq sndSeq ([|2|] |> Seq.toList)
+          assertTestFailsWithMsg msg (test, Normal)
+        }
+
+        test "fail - expected sequence contains more elements" {
+          let format = "Failing - sequence does not contain proper elements"
+          let fstSeq = [|2;1;3|]
+          let sndSeq = [|1;3;2;7|]
+          let test () = Expect.containsAll fstSeq sndSeq format
+          let msg = sprintf "%s.
+              Sequence does not contains all elements
+              Should contains:
+              %A
+              But contains:
+              %A
+              Missing values:
+              %A
+              Should not contains these values but contains:
+              %A" 
+                      format fstSeq sndSeq ([||] |> Seq.toList) ([|7|] |> Seq.toList)
+          assertTestFailsWithMsg msg (test, Normal)
+        }
+      ]
+
       testList "sequence equal" [
         testCase "pass" <| fun _ ->
           Expect.sequenceEqual [1;2;3] [1;2;3] "Sequences actually equal"

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -185,6 +185,7 @@ let contains sequence element format =
   | None ->
     Tests.failtestf "%s. Sequence did not contain %A." format element
 
+/// Expects the `actual` sequence to contain all elements from `expected` sequence (not taking into account an order of elements).
 let containsAll (actual: _ seq) (expected: _ seq) format =
   let except seqFirst seqSecond =
         seqFirst

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -207,7 +207,8 @@ let containsAll (actual: _ seq) (expected: _ seq) format =
         %A
         %s" 
               actual expected shouldContain additionalInfo
-  if not (shouldContain |> Seq.isEmpty) then  
+  let isNotCorrect = not (shouldContain |> Seq.isEmpty) || not (shouldNotContain |> Seq.isEmpty)
+  if isNotCorrect then  
     Tests.failtestf "%s.
       %s" format msg
 

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -190,13 +190,13 @@ let containsAll (actual: _ seq) (expected: _ seq) format =
         seqFirst
         |> Seq.filter(fun x -> not(seqSecond |> Seq.exists(fun y -> y = x)))
         |> Seq.toList
-  let shouldContain = except actual expected
-  let shouldNotContain = except expected actual
+  let shouldContains = except actual expected
+  let shouldNotContains = except expected actual
   let additionalInfo = 
-    if not(shouldNotContain |> Seq.isEmpty) then 
+    if not(shouldNotContains |> Seq.isEmpty) then 
       sprintf "Should not contains these values but contains:
         %A" 
-                  shouldNotContain
+                  shouldNotContains
     else ""
   let msg = sprintf "Sequence does not contains all elements.
         Should contains:
@@ -206,8 +206,8 @@ let containsAll (actual: _ seq) (expected: _ seq) format =
         Missing values:
         %A
         %s" 
-              actual expected shouldContain additionalInfo
-  let isNotCorrect = not (shouldContain |> Seq.isEmpty) || not (shouldNotContain |> Seq.isEmpty)
+              actual expected shouldContains additionalInfo
+  let isNotCorrect = not (shouldContains |> Seq.isEmpty) || not (shouldNotContains |> Seq.isEmpty)
   if isNotCorrect then  
     Tests.failtestf "%s.
       %s" format msg

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -185,6 +185,32 @@ let contains sequence element format =
   | None ->
     Tests.failtestf "%s. Sequence did not contain %A." format element
 
+let containsAll (actual: _ seq) (expected: _ seq) format =
+  let except seqFirst seqSecond =
+        seqFirst
+        |> Seq.filter(fun x -> not(seqSecond |> Seq.exists(fun y -> y = x)))
+        |> Seq.toList
+  let shouldContain = except actual expected
+  let shouldNotContain = except expected actual
+  let additionalInfo = 
+    if not(shouldNotContain |> Seq.isEmpty) then 
+      sprintf "Should not contains these values but contains:
+        %A" 
+                  shouldNotContain
+    else ""
+  let msg = sprintf "Sequence does not contains all elements.
+        Should contains:
+        %A
+        But contains:
+        %A
+        Missing values:
+        %A
+        %s" 
+              actual expected shouldContain additionalInfo
+  if not (shouldContain |> Seq.isEmpty) then  
+    Tests.failtestf "%s.
+      %s" format msg
+
 /// Expects the `actual` sequence to equal the `expected` one.
 let sequenceEqual (actual : _ seq) (expected : _ seq) format =
   use ai = actual.GetEnumerator()

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ This module is your main entry-point when asserting.
    then fail with `format` as an error message together with a description
    of `subject` and `length`.
  - `contains : 'a seq -> 'a -> string -> unit` – Expect the sequence to contain the item.
+ - `containsAll: 'a seq -> 'a seq -> string -> unit` - Expect the sequence contains all elements from second sequence (not taking into account an order of elements)
  - `streamsEqual` – Expect the streams to be byte-wise identical.
 
 ## `main argv` – how to run console apps


### PR DESCRIPTION
I saw that in Expect are available following methods:
* _contain_
* _sequenceEqual_


But the first one looks if sequence contains specific element. Second one checks if sequence is equal to another sequence (position in a list is taken into account)
So maybe it is a good idea to add containsAll method which would look if given sequence contains all elements from a second sequence (not more, not least) and not looking for their position in sequence?
So following tests should return "pass" result:
![image](https://cloud.githubusercontent.com/assets/7689103/21471626/394e2470-cab8-11e6-9b82-526808d4159a.png)
If test fails following errors will be shown:
![image](https://cloud.githubusercontent.com/assets/7689103/21471643/ce259808-cab8-11e6-944d-01be96c37d1a.png)

