### PR TITLE
Small fixes around contains all

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -443,18 +443,18 @@ let expecto =
         testCase "sequence contains everything expected" <| fun _ ->
           let format = "Sequence should contain one and five"
           let test () =
-            Expect.containsAll [|2; 1; 3|] [| 1; 5 |] format
+            Expect.containsAll [|2; 1; 1|] [| 1; 5 |] format
           let msg =
             sprintf "%s.
     Sequence `actual` does not contain all `expected` elements.
         All elements in `actual`:
-        {1, 2, 3}
+        {1, 1, 2}
         All elements in `expected`:
         {1, 5}
         Missing elements from `actual`:
         {5}
         Extra elements in `actual`:
-        {2, 3}"
+        {1, 2}"
               format
           assertTestFailsWithMsg msg (test, Normal)
       ]

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -452,9 +452,9 @@ let expecto =
         All elements in `expected`:
         {1, 5}
         Missing elements from `actual`:
-        {5}
+        {1, 2}
         Extra elements in `actual`:
-        {1, 2}"
+        {5}"
               format
           assertTestFailsWithMsg msg (test, Normal)
       ]

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -204,7 +204,7 @@ let inline private formatSet<'a> (ss : 'a seq) : string =
     |> String.concat ", "
     |> sprintf "{%s}"
 
-let inline private except(sequence: 'a seq, exceptSeq: 'a seq): 'a list =
+let inline private except(baseSeq: 'a seq, exceptSeq: 'a seq): 'a list =
   let groupByOccurances sequence =
     sequence
     |> Seq.groupBy id
@@ -223,7 +223,7 @@ let inline private except(sequence: 'a seq, exceptSeq: 'a seq): 'a list =
       differNrOfElement element
     else Array.create (snd element) (fst element) |> Array.toList
   
-  sequence
+  baseSeq
   |> groupByOccurances
   |> Seq.map elementsWhichDiffer
   |> List.concat
@@ -235,10 +235,10 @@ let containsAll (actual : _ seq)
                 (expected : _ seq)
                 format =
   let extra, missing =
-    except(expected, actual),
-    except(actual, expected)
-
-  if List.isEmpty missing then () else
+    except(actual, expected),
+    except(expected, actual)
+  let isCorrect = List.isEmpty missing && List.isEmpty extra
+  if isCorrect then () else
 
   sprintf "%s.
     Sequence `actual` does not contain all `expected` elements.


### PR DESCRIPTION
As I saw when we pass data like that:
![image](https://cloud.githubusercontent.com/assets/7689103/21481561/5ae1a830-cb69-11e6-9c8f-4a5bc9f2bde3.png)

Expecto right now will return:
![image](https://cloud.githubusercontent.com/assets/7689103/21481594/ca6109f8-cb69-11e6-9812-4044cf0ad348.png)

Expected result should be like that:
![image](https://cloud.githubusercontent.com/assets/7689103/21481563/65e5e804-cb69-11e6-8103-fa9d6d498c43.png)
@haf I saw that You refactor a little bit containsAll method so could You take a look at this fix?