### PR TITLE
Add tests' source file location 

### DIFF
--- a/Expecto.BenchmarkDotNet/Expecto.BenchmarkDotNet.fsproj
+++ b/Expecto.BenchmarkDotNet/Expecto.BenchmarkDotNet.fsproj
@@ -84,15 +84,15 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
-        <Reference Include="BenchmarkDotNet.Core">
-          <HintPath>..\packages\BenchmarkDotNet.Core\lib\net45\BenchmarkDotNet.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
         <Reference Include="System.Management">
           <Paket>True</Paket>
         </Reference>
         <Reference Include="System.Xml">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="BenchmarkDotNet.Core">
+          <HintPath>..\packages\BenchmarkDotNet.Core\lib\net45\BenchmarkDotNet.Core.dll</HintPath>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -200,8 +200,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
       <ItemGroup>
         <Reference Include="System.AppContext">
-          <HintPath>..\packages\System.AppContext\lib\net46\System.AppContext.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.AppContext\ref\net46\System.AppContext.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -209,8 +209,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.AppContext">
-          <HintPath>..\packages\System.AppContext\lib\net463\System.AppContext.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.AppContext\ref\net463\System.AppContext.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -231,8 +231,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Console">
-          <HintPath>..\packages\System.Console\lib\net46\System.Console.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Console\ref\net46\System.Console.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -242,8 +242,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Diagnostics.FileVersionInfo">
-          <HintPath>..\packages\System.Diagnostics.FileVersionInfo\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Diagnostics.FileVersionInfo\ref\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -253,19 +253,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Diagnostics.StackTrace">
-          <HintPath>..\packages\System.Diagnostics.StackTrace\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
-      <ItemGroup>
-        <Reference Include="System.IO">
-          <HintPath>..\packages\System.IO\lib\net462\System.IO.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Diagnostics.StackTrace\ref\net46\System.Diagnostics.StackTrace.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -275,8 +264,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO.FileSystem">
-          <HintPath>..\packages\System.IO.FileSystem\lib\net46\System.IO.FileSystem.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.IO.FileSystem\ref\net46\System.IO.FileSystem.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -286,8 +275,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO.FileSystem.Primitives">
-          <HintPath>..\packages\System.IO.FileSystem.Primitives\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.IO.FileSystem.Primitives\ref\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -297,8 +286,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Linq">
-          <HintPath>..\packages\System.Linq\lib\net463\System.Linq.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Linq\ref\net463\System.Linq.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -308,8 +297,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Linq.Expressions">
-          <HintPath>..\packages\System.Linq.Expressions\lib\net463\System.Linq.Expressions.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Linq.Expressions\ref\net463\System.Linq.Expressions.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -319,8 +308,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Reflection">
-          <HintPath>..\packages\System.Reflection\lib\net462\System.Reflection.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Reflection\ref\net462\System.Reflection.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -347,12 +336,12 @@
     </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
-        <Reference Include="System.Runtime">
-          <HintPath>..\packages\System.Runtime\lib\net462\System.Runtime.dll</HintPath>
-          <Private>True</Private>
+        <Reference Include="System.ComponentModel.Composition">
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="System.ComponentModel.Composition">
+        <Reference Include="System.Runtime">
+          <HintPath>..\packages\System.Runtime\ref\net462\System.Runtime.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -362,8 +351,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Runtime.Extensions">
-          <HintPath>..\packages\System.Runtime.Extensions\lib\net462\System.Runtime.Extensions.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Runtime.Extensions\ref\net462\System.Runtime.Extensions.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -373,8 +362,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.2'">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices">
-          <HintPath>..\packages\System.Runtime.InteropServices\lib\net462\System.Runtime.InteropServices.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Runtime.InteropServices\ref\net462\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -382,8 +371,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices">
-          <HintPath>..\packages\System.Runtime.InteropServices\lib\net463\System.Runtime.InteropServices.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Runtime.InteropServices\ref\net463\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -393,8 +382,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Algorithms">
-          <HintPath>..\packages\System.Security.Cryptography.Algorithms\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Algorithms\ref\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -402,8 +391,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Algorithms">
-          <HintPath>..\packages\System.Security.Cryptography.Algorithms\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Algorithms\ref\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -411,8 +400,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Algorithms">
-          <HintPath>..\packages\System.Security.Cryptography.Algorithms\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Algorithms\ref\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -422,8 +411,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Encoding">
-          <HintPath>..\packages\System.Security.Cryptography.Encoding\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Encoding\ref\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -433,8 +422,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.X509Certificates">
-          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\ref\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -442,8 +431,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.X509Certificates">
-          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\ref\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -453,19 +442,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Text.Encoding.CodePages">
-          <HintPath>..\packages\System.Text.Encoding.CodePages\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.6'">
-      <ItemGroup>
-        <Reference Include="System.Threading">
-          <HintPath>..\packages\System.Threading\lib\netstandard1.3\System.Threading.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Text.Encoding.CodePages\ref\netstandard1.3\System.Text.Encoding.CodePages.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -475,8 +453,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Threading.Thread">
-          <HintPath>..\packages\System.Threading.Thread\lib\net46\System.Threading.Thread.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Threading.Thread\ref\net46\System.Threading.Thread.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -486,17 +464,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.ReaderWriter">
-          <HintPath>..\packages\System.Xml.ReaderWriter\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.6'">
-      <ItemGroup>
-        <Reference Include="System.Xml.ReaderWriter">
-          <HintPath>..\packages\System.Xml.ReaderWriter\lib\netstandard1.3\System.Xml.ReaderWriter.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.ReaderWriter\ref\net46\System.Xml.ReaderWriter.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -510,22 +479,13 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.6'">
-      <ItemGroup>
-        <Reference Include="System.Xml.XDocument">
-          <HintPath>..\packages\System.Xml.XDocument\lib\netstandard1.3\System.Xml.XDocument.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
   </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.XmlDocument">
-          <HintPath>..\packages\System.Xml.XmlDocument\lib\net46\System.Xml.XmlDocument.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.XmlDocument\ref\net46\System.Xml.XmlDocument.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -535,8 +495,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.XPath">
-          <HintPath>..\packages\System.Xml.XPath\lib\net46\System.Xml.XPath.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.XPath\ref\net46\System.Xml.XPath.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -546,8 +506,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.XPath.XDocument">
-          <HintPath>..\packages\System.Xml.XPath.XDocument\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.XPath.XDocument\ref\net46\System.Xml.XPath.XDocument.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>

--- a/Expecto.Tests/BenchmarkDotNet.fs
+++ b/Expecto.Tests/BenchmarkDotNet.fs
@@ -30,14 +30,14 @@ let performance =
       let a = Md5VsSha256()
       let test() =
         Expect.isFasterThan a.Md5 a.Sha256 "MD5 equals SHA256 should fail"
-      assertTestFailsWithMsgContaining "same" (test, Normal)
+      assertTestFailsWithMsgContaining "same" (test, Normal, SourceLocation.Empty)
 
     testCase "sha256 versus md5" <| fun _ ->
       let a = Md5VsSha256()
 
       let test() =
         Expect.isFasterThan (a.Sha256 >> ignore) (a.Md5 >> ignore) "SHA256 is faster than MD5 should fail"
-      assertTestFailsWithMsgContaining "slower" (test, Normal)
+      assertTestFailsWithMsgContaining "slower" (test, Normal, SourceLocation.Empty)
 
     testCase "md5 versus sha256" <| fun _ ->
       let a = Md5VsSha256()

--- a/Expecto.Tests/BenchmarkDotNet.fs
+++ b/Expecto.Tests/BenchmarkDotNet.fs
@@ -30,14 +30,14 @@ let performance =
       let a = Md5VsSha256()
       let test() =
         Expect.isFasterThan a.Md5 a.Sha256 "MD5 equals SHA256 should fail"
-      assertTestFailsWithMsgContaining "same" (test, Normal, SourceLocation.Empty)
+      assertTestFailsWithMsgContaining "same" (test, Normal)
 
     testCase "sha256 versus md5" <| fun _ ->
       let a = Md5VsSha256()
 
       let test() =
         Expect.isFasterThan (a.Sha256 >> ignore) (a.Md5 >> ignore) "SHA256 is faster than MD5 should fail"
-      assertTestFailsWithMsgContaining "slower" (test, Normal, SourceLocation.Empty)
+      assertTestFailsWithMsgContaining "slower" (test, Normal)
 
     testCase "md5 versus sha256" <| fun _ ->
       let a = Md5VsSha256()

--- a/Expecto.Tests/Expecto.Tests.fsproj
+++ b/Expecto.Tests/Expecto.Tests.fsproj
@@ -106,15 +106,15 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
-        <Reference Include="BenchmarkDotNet.Core">
-          <HintPath>..\packages\BenchmarkDotNet.Core\lib\net45\BenchmarkDotNet.Core.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
         <Reference Include="System.Management">
           <Paket>True</Paket>
         </Reference>
         <Reference Include="System.Xml">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="BenchmarkDotNet.Core">
+          <HintPath>..\packages\BenchmarkDotNet.Core\lib\net45\BenchmarkDotNet.Core.dll</HintPath>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -280,8 +280,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
       <ItemGroup>
         <Reference Include="System.AppContext">
-          <HintPath>..\packages\System.AppContext\lib\net46\System.AppContext.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.AppContext\ref\net46\System.AppContext.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -289,8 +289,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.AppContext">
-          <HintPath>..\packages\System.AppContext\lib\net463\System.AppContext.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.AppContext\ref\net463\System.AppContext.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -311,8 +311,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Console">
-          <HintPath>..\packages\System.Console\lib\net46\System.Console.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Console\ref\net46\System.Console.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -322,8 +322,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Diagnostics.FileVersionInfo">
-          <HintPath>..\packages\System.Diagnostics.FileVersionInfo\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Diagnostics.FileVersionInfo\ref\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -333,19 +333,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Diagnostics.StackTrace">
-          <HintPath>..\packages\System.Diagnostics.StackTrace\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
-      <ItemGroup>
-        <Reference Include="System.IO">
-          <HintPath>..\packages\System.IO\lib\net462\System.IO.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Diagnostics.StackTrace\ref\net46\System.Diagnostics.StackTrace.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -355,8 +344,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO.FileSystem">
-          <HintPath>..\packages\System.IO.FileSystem\lib\net46\System.IO.FileSystem.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.IO.FileSystem\ref\net46\System.IO.FileSystem.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -366,8 +355,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.IO.FileSystem.Primitives">
-          <HintPath>..\packages\System.IO.FileSystem.Primitives\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.IO.FileSystem.Primitives\ref\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -377,8 +366,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Linq">
-          <HintPath>..\packages\System.Linq\lib\net463\System.Linq.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Linq\ref\net463\System.Linq.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -388,8 +377,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Linq.Expressions">
-          <HintPath>..\packages\System.Linq.Expressions\lib\net463\System.Linq.Expressions.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Linq.Expressions\ref\net463\System.Linq.Expressions.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -399,8 +388,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Reflection">
-          <HintPath>..\packages\System.Reflection\lib\net462\System.Reflection.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Reflection\ref\net462\System.Reflection.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -427,12 +416,12 @@
     </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
-        <Reference Include="System.Runtime">
-          <HintPath>..\packages\System.Runtime\lib\net462\System.Runtime.dll</HintPath>
-          <Private>True</Private>
+        <Reference Include="System.ComponentModel.Composition">
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="System.ComponentModel.Composition">
+        <Reference Include="System.Runtime">
+          <HintPath>..\packages\System.Runtime\ref\net462\System.Runtime.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -442,8 +431,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Runtime.Extensions">
-          <HintPath>..\packages\System.Runtime.Extensions\lib\net462\System.Runtime.Extensions.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Runtime.Extensions\ref\net462\System.Runtime.Extensions.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -453,8 +442,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.2'">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices">
-          <HintPath>..\packages\System.Runtime.InteropServices\lib\net462\System.Runtime.InteropServices.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Runtime.InteropServices\ref\net462\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -462,8 +451,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Runtime.InteropServices">
-          <HintPath>..\packages\System.Runtime.InteropServices\lib\net463\System.Runtime.InteropServices.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Runtime.InteropServices\ref\net463\System.Runtime.InteropServices.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -473,8 +462,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Algorithms">
-          <HintPath>..\packages\System.Security.Cryptography.Algorithms\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Algorithms\ref\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -482,8 +471,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Algorithms">
-          <HintPath>..\packages\System.Security.Cryptography.Algorithms\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Algorithms\ref\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -491,8 +480,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6.3'">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Algorithms">
-          <HintPath>..\packages\System.Security.Cryptography.Algorithms\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Algorithms\ref\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -502,8 +491,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.Encoding">
-          <HintPath>..\packages\System.Security.Cryptography.Encoding\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.Encoding\ref\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -513,8 +502,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.X509Certificates">
-          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\ref\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -522,8 +511,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Security.Cryptography.X509Certificates">
-          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Security.Cryptography.X509Certificates\ref\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -533,19 +522,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Text.Encoding.CodePages">
-          <HintPath>..\packages\System.Text.Encoding.CodePages\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.6'">
-      <ItemGroup>
-        <Reference Include="System.Threading">
-          <HintPath>..\packages\System.Threading\lib\netstandard1.3\System.Threading.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Text.Encoding.CodePages\ref\netstandard1.3\System.Text.Encoding.CodePages.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -555,8 +533,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Threading.Thread">
-          <HintPath>..\packages\System.Threading.Thread\lib\net46\System.Threading.Thread.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Threading.Thread\ref\net46\System.Threading.Thread.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -566,17 +544,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.ReaderWriter">
-          <HintPath>..\packages\System.Xml.ReaderWriter\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.6'">
-      <ItemGroup>
-        <Reference Include="System.Xml.ReaderWriter">
-          <HintPath>..\packages\System.Xml.ReaderWriter\lib\netstandard1.3\System.Xml.ReaderWriter.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.ReaderWriter\ref\net46\System.Xml.ReaderWriter.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -590,22 +559,13 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.6'">
-      <ItemGroup>
-        <Reference Include="System.Xml.XDocument">
-          <HintPath>..\packages\System.Xml.XDocument\lib\netstandard1.3\System.Xml.XDocument.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
   </Choose>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.XmlDocument">
-          <HintPath>..\packages\System.Xml.XmlDocument\lib\net46\System.Xml.XmlDocument.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.XmlDocument\ref\net46\System.Xml.XmlDocument.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -615,8 +575,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.XPath">
-          <HintPath>..\packages\System.Xml.XPath\lib\net46\System.Xml.XPath.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.XPath\ref\net46\System.Xml.XPath.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
@@ -626,8 +586,8 @@
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
         <Reference Include="System.Xml.XPath.XDocument">
-          <HintPath>..\packages\System.Xml.XPath.XDocument\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
-          <Private>True</Private>
+          <HintPath>..\packages\System.Xml.XPath.XDocument\ref\net46\System.Xml.XPath.XDocument.dll</HintPath>
+          <Private>False</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>

--- a/Expecto.Tests/FocusedTests.fs
+++ b/Expecto.Tests/FocusedTests.fs
@@ -73,7 +73,7 @@ let all =
         result.passed.Length ==? 11
         result.ignored.Length ==? 19
     testCase "can detect focused test" <| fun _ ->
-      let localList = 
+      let localList =
         testList "local" [
           ftestList "focused" [
             testCase "test" (fun () -> ())
@@ -84,7 +84,7 @@ let all =
       if runTests { defaultConfig with failOnFocusedTests = true } localList <> 1 then
         failwith "focused test check didn't fail"
     testCase "can run if no focused test was found" <| fun _ ->
-      let localList = 
+      let localList =
         testList "local" [
           testList "focused" [
             testCase "test" (fun () -> ())

--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -76,13 +76,27 @@ module TestHelpers =
           |> Gen.suchThat (fun t -> t.Days = 0)
       )
 
+  let genTestRunResult =
+    lazy (
+      gen {
+        let! name = Arb.generate<string>
+        let! duration = genLimitedTimeSpan.Value
+
+        return
+          { TestRunResult.name = name
+            location = SourceLocation.Empty
+            result = Passed
+            duration = duration }
+      }
+    )
+
   let genTestResultCounts =
       lazy (
           gen {
-              let! passed = Arb.generate<string list>
-              let! ignored = Arb.generate<string list>
-              let! failed = Arb.generate<string list>
-              let! errored = Arb.generate<string list>
+              let! passed =  genTestRunResult.Value |> Gen.listOf
+              let! ignored = genTestRunResult.Value |> Gen.listOf
+              let! failed = genTestRunResult.Value |> Gen.listOf
+              let! errored = genTestRunResult.Value |> Gen.listOf
               let! duration = genLimitedTimeSpan.Value
               return
                 { TestResultSummary.passed = passed

--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -43,7 +43,7 @@ module TestHelpers =
   open Expecto
   open Expecto.Impl
 
-  let evalSilent = eval TestPrinters.silent List.map
+  let evalSilent = eval (fun _ -> SourceLocation.Empty) TestPrinters.silent List.map
 
   let inline assertTestFails test =
     let test = TestCase test

--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -43,7 +43,7 @@ module TestHelpers =
   open Expecto
   open Expecto.Impl
 
-  let evalSilent = eval (fun _ -> SourceLocation.Empty) TestPrinters.silent List.map
+  let evalSilent = eval (fun _ -> SourceLocation.empty) TestPrinters.silent List.map
 
   let inline assertTestFails test =
     let test = TestCase test
@@ -84,7 +84,7 @@ module TestHelpers =
 
         return
           { TestRunResult.name = name
-            location = SourceLocation.Empty
+            location = SourceLocation.empty
             result = Passed
             duration = duration }
       }

--- a/Expecto.Tests/SummaryTests.fs
+++ b/Expecto.Tests/SummaryTests.fs
@@ -2,18 +2,26 @@ module Expecto.SummaryTests
 #nowarn "46"
 
 open Expecto
+open Impl
 open System
 
-let getRelevantPart (text:string) = 
+let getRelevantPart (text:string) =
     text.Split([|"EXPECTO?! Summary..."|],StringSplitOptions.None).[1]
     |> fun s -> s.TrimStart()
     |> fun s -> s.Replace(" []","")
+
+let testResult name = {
+  name = name
+  location = SourceLocation.empty
+  result = Passed
+  duration = TimeSpan.MinValue
+}
 
 [<Tests>]
 let tests =
   testList "summary tests" [
     testCase "can log empty summary" <| fun _ ->
-      let text = 
+      let text =
         Expecto.Impl.createSummaryText
           { passed = []
             ignored = []
@@ -25,9 +33,9 @@ let tests =
       Expect.equal text "Passed:  0\nIgnored: 0\nFailed:  0\nErrored: 0" "empty"
 
     testCase "can log one passed test" <| fun _ ->
-      let text = 
+      let text =
         Expecto.Impl.createSummaryText
-          { passed = ["test 1"]
+          { passed = [testResult "test 1"]
             ignored = []
             failed = []
             errored = []
@@ -37,9 +45,9 @@ let tests =
       Expect.equal text "Passed:  1\n\ttest 1\nIgnored: 0\nFailed:  0\nErrored: 0" "one passed test"
 
     testCase "can log 10 passed test" <| fun _ ->
-      let text = 
+      let text =
         Expecto.Impl.createSummaryText
-          { passed = [1..10] |> List.map (fun x -> "test " + x.ToString())
+          { passed = [1..10] |> List.map (fun x -> "test " + x.ToString() |> testResult)
             ignored = []
             failed = []
             errored = []

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -56,7 +56,7 @@ let tests =
           %s
           String `actual` was shorter than expected, at pos %i for expected item %A."
             format expected diffString 4 actual diffString 4 '2'
-        assertTestFailsWithMsg msg (test, Normal, SourceLocation.Empty)
+        assertTestFailsWithMsg msg (test, Normal)
       }
 
       test "different length, actual is longer" {
@@ -72,7 +72,7 @@ let tests =
                ↑
           String `actual` was longer than expected, at pos 4 found item '2'."""
             format
-        assertTestFailsWithMsg msg (test, Normal, SourceLocation.Empty)
+        assertTestFailsWithMsg msg (test, Normal)
       }
 
       test "fail - different content" {
@@ -89,7 +89,7 @@ let tests =
               ↑
           String does not match at position 3. Expected char: '2', but got 't'."""
             format
-        assertTestFailsWithMsg msg (test, Normal, SourceLocation.Empty)
+        assertTestFailsWithMsg msg (test, Normal)
       }
     ]
 
@@ -146,7 +146,7 @@ let tests =
     testList "Exception handling" [
       testCase "Expecto ignore" <| fun _ ->
         let test () = skiptest "b"
-        let test = TestCase (test, Normal, SourceLocation.Empty)
+        let test = TestCase (test, Normal)
         match evalSilent test with
         | [{ result = Ignored "b" }] -> ()
         | x -> failtestf "Expected result = Ignored, got\n %A" x
@@ -223,11 +223,11 @@ let expecto =
 
     testSequenced <| testList "Timeout" [
       testCase "fail" <| fun _ ->
-        let test = TestCase(Test.timeout 10 (fun _ -> Thread.Sleep 100), Normal, SourceLocation.Empty)
+        let test = TestCase(Test.timeout 10 (fun _ -> Thread.Sleep 100), Normal)
         let result = evalSilent test |> sumTestResults
         result.failed.Length ==? 1
       testCase "pass" <| fun _ ->
-        let test = TestCase(Test.timeout 1000 ignore, Normal, SourceLocation.Empty)
+        let test = TestCase(Test.timeout 1000 ignore, Normal)
         let result = evalSilent test |> sumTestResults
         result.passed.Length ==? 1
     ]
@@ -381,7 +381,7 @@ let expecto =
 
         testCase "fail" <| fun _ ->
           let test () = Expect.notEqual "" "" "should fail"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "raise" [
@@ -394,12 +394,12 @@ let expecto =
             Expect.throwsT<ArgumentException> (fun _ -> nullArg "")
                                               "Expected argument exception."
 
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
 
         testCase "fail with no exception" <| fun _ ->
           let test () =
             Expect.throwsT<ArgumentNullException> ignore "Ignore 'should' throw an exn, ;)"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "string contain" [
@@ -408,7 +408,7 @@ let expecto =
 
         testCase "fail" <| fun _ ->
           let test () = Expect.stringContains "hello world" "a" "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "string starts" [
@@ -417,7 +417,7 @@ let expecto =
 
         testCase "fail" <| fun _ ->
           let test () = Expect.stringStarts "hello world" "a" "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "string ends" [
@@ -426,7 +426,7 @@ let expecto =
 
         testCase "fail" <| fun _ ->
           let test () = Expect.stringEnds "hello world" "a" "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "string has length" [
@@ -435,7 +435,7 @@ let expecto =
 
         testCase "fail" <| fun _ ->
           let test () = Expect.stringHasLength "hello world" 5 "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "#containsAll" [
@@ -462,7 +462,7 @@ let expecto =
         Extra elements in `actual`:
         {2, 3}"
               format
-          assertTestFailsWithMsg msg (test, Normal, SourceLocation.Empty)
+          assertTestFailsWithMsg msg (test, Normal)
       ]
 
       testList "#distribution" [
@@ -550,11 +550,11 @@ let expecto =
 
         testCase "fail - longer" <| fun _ ->
           let test () = Expect.sequenceEqual [1;2;3] [1] "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
 
         testCase "fail - shorter" <| fun _ ->
           let test () = Expect.sequenceEqual [1] [1;2;3] "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "sequence starts" [
@@ -563,11 +563,11 @@ let expecto =
 
         testCase "fail - different" <| fun _ ->
           let test () = Expect.sequenceStarts [1;2;3] [2] "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
 
         testCase "fail - subject shorter" <| fun _ ->
           let test () = Expect.sequenceStarts [1] [1;2;3] "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "sequence ascending" [
@@ -576,7 +576,7 @@ let expecto =
 
         testCase "fail " <| fun _ ->
           let test () = Expect.isAscending [1;3;2] "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
       testList "sequence descending" [
@@ -585,7 +585,7 @@ let expecto =
 
         testCase "fail " <| fun _ ->
           let test () = Expect.isDescending [3;1;2] "Deliberately failing"
-          assertTestFails (test, Normal, SourceLocation.Empty)
+          assertTestFails (test, Normal)
       ]
 
     ]
@@ -638,7 +638,7 @@ let performance =
     testCase "1 <> 2" <| fun _ ->
       let test () =
         Expect.isFasterThan (fun () -> 1) (fun () -> 2) "1 equals 2 should fail"
-      assertTestFailsWithMsgContaining "same" (test, Normal, SourceLocation.Empty)
+      assertTestFailsWithMsgContaining "same" (test, Normal)
 
     testCase "half is faster" <| fun _ ->
       Expect.isFasterThan (fun () -> repeat10000 log 76.0)
@@ -650,14 +650,14 @@ let performance =
         Expect.isFasterThan (fun () -> repeat10000 log 76.0 |> ignore; repeat10000 log 76.0)
                             (fun () -> repeat10000 log 76.0)
                             "double is faster should fail"
-      assertTestFailsWithMsgContaining "slower" (test, Normal, SourceLocation.Empty)
+      assertTestFailsWithMsgContaining "slower" (test, Normal)
 
     ptestCase "same function is faster should fail" <| fun _ ->
       let test () =
         Expect.isFasterThan (fun () -> repeat100000 log 76.0)
                             (fun () -> repeat100000 log 76.0)
                             "same function is faster should fail"
-      assertTestFailsWithMsgContaining "equal" (test, Normal, SourceLocation.Empty)
+      assertTestFailsWithMsgContaining "equal" (test, Normal)
 
     testCase "matrix" <| fun _ ->
       let n = 100
@@ -693,5 +693,5 @@ let performance =
         Expect.isFasterThan (fun () -> repeat10000 (popCount16 >> int) 987us)
                             (fun () -> repeat10000 (popCount >> int) 987us)
                             "popcount 16 faster than 32 fails"
-      assertTestFailsWithMsgContaining "slower" (test, Normal, SourceLocation.Empty)
+      assertTestFailsWithMsgContaining "slower" (test, Normal)
   ]

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -537,10 +537,10 @@ let expecto =
         All elements in `expected` ['item', 'number of expected occurrences']:
         {2: 1, 4: 1}
         Missing elements from `actual`:
-
+        %s
         Extra elements in `actual`:
         '2' (2/1)"
-              format
+              format ""
           assertTestFailsWithMsg msg (test, Normal)
       ]
 

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -95,12 +95,12 @@ let tests =
 
     testList "sumTestResults" [
       let sumTestResultsTests =
-        [ { TestRunResult.name = ""; result = Passed; duration = TimeSpan.FromMinutes 2.; location =  SourceLocation.Empty }
-          { TestRunResult.name = ""; result = TestResult.Error (ArgumentException()); duration = TimeSpan.FromMinutes 3.; location =  SourceLocation.Empty }
-          { TestRunResult.name = ""; result = Failed ""; duration = TimeSpan.FromMinutes 4.; location =  SourceLocation.Empty }
-          { TestRunResult.name = ""; result = Passed; duration = TimeSpan.FromMinutes 5.; location =  SourceLocation.Empty }
-          { TestRunResult.name = ""; result = Failed ""; duration = TimeSpan.FromMinutes 6.; location =  SourceLocation.Empty }
-          { TestRunResult.name = ""; result = Passed; duration = TimeSpan.FromMinutes 7.; location =  SourceLocation.Empty }
+        [ { TestRunResult.name = ""; result = Passed; duration = TimeSpan.FromMinutes 2.; location = SourceLocation.empty }
+          { TestRunResult.name = ""; result = TestResult.Error (ArgumentException()); duration = TimeSpan.FromMinutes 3.; location =SourceLocation.empty }
+          { TestRunResult.name = ""; result = Failed ""; duration = TimeSpan.FromMinutes 4.; location = SourceLocation.empty }
+          { TestRunResult.name = ""; result = Passed; duration = TimeSpan.FromMinutes 5.; location = SourceLocation.empty }
+          { TestRunResult.name = ""; result = Failed ""; duration = TimeSpan.FromMinutes 6.; location = SourceLocation.empty }
+          { TestRunResult.name = ""; result = Passed; duration = TimeSpan.FromMinutes 7.; location = SourceLocation.empty }
         ]
       let r = lazy sumTestResults sumTestResultsTests
       yield testCase "passed" <| fun _ ->
@@ -135,7 +135,7 @@ let tests =
       testCase "ToString" <| fun _ ->
         let tr = {
           name = ""
-          location = SourceLocation.Empty
+          location =SourceLocation.empty
           result = Passed
           duration = TimeSpan.MaxValue
         }
@@ -537,7 +537,7 @@ let expecto =
         All elements in `expected` ['item', 'number of expected occurrences']:
         {2: 1, 4: 1}
         Missing elements from `actual`:
-        
+
         Extra elements in `actual`:
         '2' (2/1)"
               format

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -291,10 +291,10 @@ module Impl =
 
   [<StructuredFormatDisplay("{description}")>]
   type TestResultSummary =
-    { passed   : string list
-      ignored  : string list
-      failed   : string list
-      errored  : string list
+    { passed   : TestRunResult list
+      ignored  : TestRunResult list
+      failed   : TestRunResult list
+      errored  : TestRunResult list
       duration : TimeSpan }
 
       member x.total =
@@ -316,8 +316,8 @@ module Impl =
       static member errorCode (c: TestResultSummary) =
         (if c.failed.Length > 0 then 1 else 0) ||| (if c.errored.Length > 0 then 2 else 0)
 
-  [<StructuredFormatDisplay("{description}")>]
-  type TestRunResult =
+
+  and [<StructuredFormatDisplay("{description}")>] TestRunResult =
    { name     : string
      location : SourceLocation
      result   : TestResult
@@ -339,7 +339,7 @@ module Impl =
 
     let get result =
       match counts.TryGetValue (TestResult.tag result) with
-      | true, v -> v |> Seq.map (fun r -> r.name) |> Seq.toList
+      | true, v -> v |> Seq.toList
       | _ -> List.empty
 
     { passed   = get TestResult.Passed
@@ -362,6 +362,7 @@ module Impl =
   let createSummaryMessage (summary: TestResultSummary) =
     let handleLineBreaks elements =
         elements
+        |> List.map (fun n -> n.name)
         |> List.map (fun x -> "\n\t" + x)
         |> String.concat ""
 
@@ -380,7 +381,7 @@ module Impl =
         |> List.max
 
     let align (d:int) offset = d.ToString().PadLeft(offset + digits)
-    
+
     eventX "EXPECTO?! Summary...\nPassed: {passedCount}{passed}\nIgnored: {ignoredCount}{ignored}\nFailed: {failedCount}{failed}\nErrored: {erroredCount}{errored}"
     >> setField "passed" passed
     >> setField "passedCount" (align passedCount 1)

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -7,11 +7,10 @@ open System.Linq
 open System.Runtime.CompilerServices
 open System.Reflection
 
-type SourceLocation = {
-  sourcePath: string
-  lineNumber: int
-}
-with static member Empty = {sourcePath = ""; lineNumber = 0}
+type SourceLocation =
+  { sourcePath: string
+    lineNumber: int }
+with static member empty = {sourcePath = ""; lineNumber = 0}
 
 
 /// Actual test function
@@ -174,7 +173,7 @@ module Test =
             then name
             else parentName + "/" + name
         loop fullName testList (computeChildFocusState parentState state) sequenced test
-      | TestCase (test, state) -> {name=parentName; test=test; state=computeChildFocusState parentState state; sequenced=sequenced;} :: testList
+      | TestCase (test, state) -> {name=parentName; test=test; state=computeChildFocusState parentState state; sequenced=sequenced} :: testList
       | TestList (tests, state) -> List.collect (loop parentName testList (computeChildFocusState parentState state) sequenced) tests
       | Sequenced test -> loop parentName testList parentState true test
     loop null [] Normal false
@@ -183,7 +182,7 @@ module Test =
   let rec wrap f =
     function
     | TestCase (test, state) -> TestCase ((f test), state)
-    | TestList (testList, state) -> TestList ((List.map (wrap f) testList), state)
+    | TestList (testList, state) -> TestList (testList |> List.map (wrap f), state)
     | TestLabel (label, test, state) -> TestLabel (label, wrap f test, state)
     | Sequenced test -> Sequenced (wrap f test)
 
@@ -821,7 +820,7 @@ module Impl =
       |> Option.map (fun i -> i.SequencePoint)
 
     match getMethods className with
-    | None -> SourceLocation.Empty
+    | None -> SourceLocation.empty
     | Some methods ->
       let candidateSequencePoints =
         methods
@@ -830,7 +829,7 @@ module Impl =
         |> Seq.sortBy (fun sp -> sp.StartLine)
         |> Seq.toList
       match candidateSequencePoints with
-      | [] -> SourceLocation.Empty
+      | [] -> SourceLocation.empty
       | xs -> {sourcePath = xs.Head.Document.Url ; lineNumber = xs.Head.StartLine}
 
   //val apply : f:(TestCode * FocusState * SourceLocation -> TestCode * FocusState * SourceLocation) -> _arg1:Test -> Test
@@ -986,7 +985,7 @@ module Tests =
       failOnFocusedTests = false
       printer   = TestPrinters.Default
       verbosity = LogLevel.Info
-      locate = fun _ -> SourceLocation.Empty }
+      locate = fun _ -> SourceLocation.empty }
 
   type CLIArguments =
     | Sequenced

--- a/Expecto/Expecto.fsproj
+++ b/Expecto/Expecto.fsproj
@@ -150,4 +150,111 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net20\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net20\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\Mono.Cecil\lib\net20\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net35\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net35\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\Mono.Cecil\lib\net35\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\Mono.Cecil\lib\net35\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.0'">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\Mono.Cecil\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\Mono.Cecil\lib\net40\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\Mono.Cecil\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\Mono.Cecil\lib\net45\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0'">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\Mono.Cecil\lib\sl5\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\Mono.Cecil\lib\sl5\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/Expecto/paket.references
+++ b/Expecto/paket.references
@@ -1,3 +1,4 @@
 FSharp.Core
 Argu
+Mono.Cecil
 File:Facade.fs

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,12 +5,13 @@ source https://www.myget.org/F/netcorecli-fsc-preview3
 
 github logary/logary src/Logary.Facade/Facade.fs 4b21d888e83d72d1238ab0f36110e2a3946240e7
 
-nuget Argu 
+nuget Argu
 nuget FsCheck
 nuget FSharp.Core ~> 3
 nuget FSharpx.Core
 nuget BenchmarkDotNet
 nuget NuGet.CommandLine
+nuget Mono.Cecil
 
 group build
     source https://www.nuget.org/api/v2
@@ -23,6 +24,6 @@ group netcore
    # nuget NETStandard.Library 1.6.1
    # nuget System.Diagnostics.TraceSource 4.3.0
    # nuget System.Linq.Parallel 4.3.0
-   # 
+   #
    # nuget Argu 3.3.0
    # nuget FSharp.Core 4.0.1.7-alpha alpha

--- a/paket.lock
+++ b/paket.lock
@@ -117,37 +117,30 @@ NUGET
     Microsoft.NETCore.DotNetHostResolver (1.1) - framework: net10, net11, net20, net30, net35, net40, net40-full
       Microsoft.NETCore.DotNetHost (>= 1.1)
     Microsoft.NETCore.Jit (1.1) - framework: net10, net11, net20, net30, net35, net40, net40-full
-    Microsoft.NETCore.Platforms (1.1) - framework: >= net46, >= netstandard16
     Microsoft.NETCore.Runtime.CoreCLR (1.1) - framework: net10, net11, net20, net30, net35, net40, net40-full
       Microsoft.NETCore.Jit (>= 1.1)
       Microsoft.NETCore.Windows.ApiSets (>= 1.0.1)
-    Microsoft.NETCore.Targets (1.1) - framework: >= net46, >= netstandard16
     Microsoft.NETCore.Windows.ApiSets (1.0.1) - framework: net10, net11, net20, net30, net35, net40, net40-full
     Microsoft.VisualBasic (10.1) - framework: net10, net11, net20, net30, net35, net40, net40-full
+    Mono.Cecil (0.9.6.4)
     NETStandard.Library (1.6.1) - framework: net10, net11, net20, net30, net35, net40, net40-full
     NuGet.CommandLine (3.5)
     System.AppContext (4.3) - framework: >= net46
     System.Buffers (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
-    System.Collections (4.3) - framework: >= net46, >= netstandard16
+    System.Collections (4.3) - framework: >= net46
     System.Collections.Concurrent (4.3) - framework: >= net46
     System.ComponentModel (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.ComponentModel.Annotations (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Console (4.3) - framework: >= net46
-    System.Diagnostics.Debug (4.3) - framework: >= net46, >= netstandard16
+    System.Diagnostics.Debug (4.3) - framework: >= net46
     System.Diagnostics.DiagnosticSource (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Diagnostics.FileVersionInfo (4.3) - framework: >= net46
     System.Diagnostics.Process (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Diagnostics.StackTrace (4.3) - framework: >= net46
-    System.Diagnostics.Tools (4.3) - framework: >= net46, >= netstandard16
+    System.Diagnostics.Tools (4.3) - framework: >= net46
     System.Dynamic.Runtime (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full, >= net46
-    System.Globalization (4.3) - framework: >= net46, >= netstandard16
+    System.Globalization (4.3) - framework: >= net46
     System.Globalization.Extensions (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
-    System.IO (4.3) - framework: >= net46, >= netstandard16
-      Microsoft.NETCore.Platforms (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      Microsoft.NETCore.Targets (>= 1.1) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Text.Encoding (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
-      System.Threading.Tasks (>= 4.3) - framework: dnxcore50, netstandard10, netstandard13, >= netstandard15
     System.IO.FileSystem (4.3) - framework: >= net46
       System.IO.FileSystem.Primitives (>= 4.3) - framework: >= net46, >= netstandard13
     System.IO.FileSystem.Primitives (4.3) - framework: >= net46
@@ -163,14 +156,14 @@ NUGET
     System.Net.Security (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Net.WebHeaderCollection (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Numerics.Vectors (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
-    System.Reflection (4.3) - framework: >= net46, >= netstandard16
+    System.Reflection (4.3) - framework: >= net46
     System.Reflection.DispatchProxy (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Reflection.Primitives (4.3) - framework: >= net46
     System.Reflection.TypeExtensions (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Resources.Reader (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
-    System.Resources.ResourceManager (4.3) - framework: >= net46, >= netstandard16
-    System.Runtime (4.3) - framework: >= net46, >= netstandard16
-    System.Runtime.Extensions (4.3) - framework: >= net46, >= netstandard16
+    System.Resources.ResourceManager (4.3) - framework: >= net46
+    System.Runtime (4.3) - framework: >= net46
+    System.Runtime.Extensions (4.3) - framework: >= net46
     System.Runtime.Handles (4.3) - framework: >= net46
     System.Runtime.InteropServices (4.3) - framework: >= net46
       System.Runtime (>= 4.3) - framework: net462, >= net463, dnxcore50, netstandard11, netstandard12, netstandard13, >= netstandard15
@@ -181,30 +174,18 @@ NUGET
     System.Security.Cryptography.Encoding (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full, >= net46
     System.Security.Cryptography.Primitives (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Security.Cryptography.X509Certificates (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full, >= net46
-    System.Text.Encoding (4.3) - framework: >= net46, >= netstandard16
+    System.Text.Encoding (4.3) - framework: >= net46
     System.Text.Encoding.CodePages (4.3) - framework: >= net46
     System.Text.Encoding.Extensions (4.3) - framework: >= net46
-    System.Threading (4.3) - framework: >= net46, >= netstandard16
-    System.Threading.Tasks (4.3) - framework: >= net45, >= netstandard16
+    System.Threading (4.3) - framework: >= net46
+    System.Threading.Tasks (4.3) - framework: >= net45
     System.Threading.Tasks.Dataflow (4.7) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Threading.Tasks.Extensions (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
     System.Threading.Tasks.Parallel (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full, >= net46
     System.Threading.Thread (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full, >= net46
     System.Threading.ThreadPool (4.3) - framework: net10, net11, net20, net30, net35, net40, net40-full
-    System.Xml.ReaderWriter (4.3) - framework: >= net46, >= netstandard16
-    System.Xml.XDocument (4.3) - framework: >= net46, >= netstandard16
-      System.Collections (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Debug (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Diagnostics.Tools (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Globalization (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.IO (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Reflection (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Resources.ResourceManager (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Runtime (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
-      System.Runtime.Extensions (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Text.Encoding (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Threading (>= 4.3) - framework: dnxcore50, >= netstandard13
-      System.Xml.ReaderWriter (>= 4.3) - framework: dnxcore50, netstandard10, >= netstandard13
+    System.Xml.ReaderWriter (4.3) - framework: >= net46
+    System.Xml.XDocument (4.3) - framework: >= net46
     System.Xml.XmlDocument (4.3) - framework: >= net46
     System.Xml.XPath (4.3) - framework: >= net46
     System.Xml.XPath.XDocument (4.3) - framework: >= net46


### PR DESCRIPTION
Adds ability to print out test location (source file, line of code). Still work in progress. 

Cons:
* As far as I understand there are certain limitations (it's based on Pdb files so won't work in release configs etc)
* It adds a bit of complexity and additional dependency (`Mono.Cecil`)

Pros:
* It will allow much better editor integrations. (For example in VSCode in watch mode marking which tests are passing and which not)