### PR TITLE
Create a new function runTestsWithArgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ BenchmarkDotNet.Artifacts/
 /.fake/
 /.vs/
 build/
+*.orig

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -887,7 +887,9 @@ module Tests =
     |> Test.toTestCodeList
     |> Seq.iter (fun t -> printfn "%s" t.name)
 
-  /// Runs tests with supplied options. Returns 0 if all tests passed, otherwise 1.
+  /// Runs tests with the supplied options.
+
+  /// Returns 0 if all tests passed, otherwise 1
   let runTests config (tests:Test) =
     let run = if config.parallel then runParallel else run
     Global.initialiseIfDefault
@@ -898,14 +900,18 @@ module Tests =
     else
       1
 
-  /// Runs tests in this assembly with supplied command-line options.
-  /// Returns 0 if all tests passed, otherwise 1
-  let runTestsInAssembly config args =
-    let tests = testFromThisAssembly () |> Option.orDefault (TestList ([], Normal))
-    let config, isList = args |> ExpectoConfig.fillFromArgs config
-    let tests = tests |> config.filter
+  /// Runs all given tests with the supplied command-line options. Returns 0 if all tests passed, otherwise 1
+  let runTestsWithArgs config args tests =
+    let config, isList = ExpectoConfig.fillFromArgs config args
+    let tests = config.filter tests
     if isList then
       listTests tests
       0
     else
       runTests config tests
+
+  /// Runs tests in this assembly with the supplied command-line options. Returns 0 if all tests passed, otherwise 1
+  let runTestsInAssembly config args =
+    testFromThisAssembly () 
+    |> Option.orDefault (TestList ([], Normal))
+    |> runTestsWithArgs config args

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -888,7 +888,6 @@ module Tests =
     |> Seq.iter (fun t -> printfn "%s" t.name)
 
   /// Runs tests with the supplied options.
-
   /// Returns 0 if all tests passed, otherwise 1
   let runTests config (tests:Test) =
     let run = if config.parallel then runParallel else run
@@ -900,7 +899,8 @@ module Tests =
     else
       1
 
-  /// Runs all given tests with the supplied command-line options. Returns 0 if all tests passed, otherwise 1
+  /// Runs all given tests with the supplied command-line options.
+  /// Returns 0 if all tests passed, otherwise 1
   let runTestsWithArgs config args tests =
     let config, isList = ExpectoConfig.fillFromArgs config args
     let tests = config.filter tests
@@ -910,8 +910,9 @@ module Tests =
     else
       runTests config tests
 
-  /// Runs tests in this assembly with the supplied command-line options. Returns 0 if all tests passed, otherwise 1
+  /// Runs tests in this assembly with the supplied command-line options.
+  /// Returns 0 if all tests passed, otherwise 1
   let runTestsInAssembly config args =
-    testFromThisAssembly () 
+    testFromThisAssembly ()
     |> Option.orDefault (TestList ([], Normal))
     |> runTestsWithArgs config args


### PR DESCRIPTION
This will allow users to supply their own tests and still use the command line args