### PR TITLE
Docs for --fail-on-focused-tests and runTestsWithArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ operating system as error code.
 Signature `ExpectoConfig -> Test -> int`. Runs the passed tests with the passed
 configuration record.
 
+### `runTestsWithArgs`
+
+Signature `ExpectoConfig -> string[] -> Test -> int`. Runs the passed tests
+and also overrides the passed `ExpectoConfig` with the command line parameters.
+
 ### `runTestsInAssembly`
 
 Signature `ExpectoConfig -> string[] -> int`. Runs the tests in the current
@@ -177,6 +182,9 @@ let focusedTests =
     testCase "skipped" <| fun _ -> Expect.equal (2+2) 1 "2+2?"
   ]
 ```
+
+Expecto accepts the command line argument `--fail-on-focused-tests`, which checks if focused tests exist.
+This parameter can be set in build scripts and allows CI servers to reject commits that accidentally included focused tests.
 
 ### Pending tests
 


### PR DESCRIPTION
@haf since you don't seem to use release_notes.md I have the paragraph here:

* This release provides a `runTestsWithArgs` function which runs the passed tests and also overrides the passed `ExpectoConfig` with the command line parameters.
* Expecto now accepts the command line argument `--fail-on-focused-tests`, which checks if focused tests exist. This parameter can be set in build scripts and allows CI servers to reject commits that accidentally included focused tests.