### PR TITLE
fix mutable sync/async logging and support async tests

### DIFF
--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -43,7 +43,7 @@ module TestHelpers =
   open Expecto
   open Expecto.Impl
 
-  let evalSilent = eval (fun _ -> SourceLocation.empty) TestPrinters.silent List.map
+  let evalSilent = eval (fun _ -> SourceLocation.empty) TestPrinters.silent true List.map
 
   let inline assertTestFails test =
     let test = TestCase test

--- a/Expecto.Tests/Prelude.fs
+++ b/Expecto.Tests/Prelude.fs
@@ -47,6 +47,11 @@ module TestHelpers =
     eval {Tests.defaultConfig with printer=TestPrinters.silent}
          (fun m l -> List.map (m>>Async.RunSynchronously) l)
 
+  let inline assetTestFails' test =
+    match evalSilent test with
+    | [{ TestRunResult.result = TestResult.Failed _ }] -> ()
+    | x -> failtestf "Should have failed, but was %A" x
+
   let inline assertTestFails (test,focusState) =
     let test = TestCase (Sync test,focusState)
     match evalSilent test with

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -623,6 +623,29 @@ let popcountTest =
   ]
 
 [<Tests>]
+let async =
+  testList "async" [
+
+    testCaseAsync "simple" <| async {
+      Expect.equal 1 1 "1=1"
+    }
+
+    testCaseAsync "let" <| async {
+      let! n = async { return 1 }
+      Expect.equal 1 n "1=n"
+    }
+
+    testCase "can fail" <| fun _ ->
+      let test =
+        testCaseAsync "let" <| async {
+          let! n = async { return 2 }
+          Expect.equal 1 n "1=n"
+        }
+      assetTestFails' test
+
+  ]
+
+[<Tests>]
 let performance =
   testSequenced <| testList "performance" [
 

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -146,7 +146,7 @@ let tests =
     testList "Exception handling" [
       testCase "Expecto ignore" <| fun _ ->
         let test () = skiptest "b"
-        let test = TestCase (test, Normal)
+        let test = TestCase (Sync test, Normal)
         match evalSilent test with
         | [{ result = Ignored "b" }] -> ()
         | x -> failtestf "Expected result = Ignored, got\n %A" x
@@ -223,11 +223,11 @@ let expecto =
 
     testSequenced <| testList "Timeout" [
       testCase "fail" <| fun _ ->
-        let test = TestCase(Test.timeout 10 (fun _ -> Thread.Sleep 100), Normal)
+        let test = TestCase(Test.timeout 10 (async { do! Async.Sleep 100 } |> Async), Normal)
         let result = evalSilent test |> sumTestResults
         result.failed.Length ==? 1
       testCase "pass" <| fun _ ->
-        let test = TestCase(Test.timeout 1000 ignore, Normal)
+        let test = TestCase(Test.timeout 1000 (Sync ignore), Normal)
         let result = evalSilent test |> sumTestResults
         result.passed.Length ==? 1
     ]
@@ -337,13 +337,16 @@ let expecto =
 
     testList "transformations" [
       testCase "multiple cultures" <| fun _ ->
-        let withCulture culture f x =
-          let c = Thread.CurrentThread.CurrentCulture
-          try
-            Thread.CurrentThread.CurrentCulture <- culture
-            f x
-          finally
-            Thread.CurrentThread.CurrentCulture <- c
+        let withCulture culture test =
+          fun () ->
+            let c = Thread.CurrentThread.CurrentCulture
+            try
+              Thread.CurrentThread.CurrentCulture <- culture
+              match test with
+              | Sync test -> test()
+              | Async test -> Async.StartImmediate test
+            finally
+              Thread.CurrentThread.CurrentCulture <- c
 
         let testWithCultures (cultures: #seq<CultureInfo>) =
           Test.replaceTestCode <| fun name test ->

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -434,14 +434,13 @@ let isFasterThanSub (f1:Performance.Measurer<_,_>->'a) (f2:Performance.Measurer<
     Tests.failtestf "%s. Expected f1 (%s) to be faster than f2 (%s) but is ~%.0f%% slower."
                     format (toString s1) (toString s2) ((s1.mean/s2.mean-1.0)*100.0)
   | Performance.MetricLessThan (s1,s2) ->
-    Impl.logger.infoWithBP (
+    Impl.logger.log Info (
       eventX "{message}. f1 ({sample1}) is {percent} faster than f2 ({sample2})."
       >> setField "message" format
       >> setField "sample1" (toString s1)
       >> setField "percent" (sprintf "~%.0f%%" ((1.0-s1.mean/s2.mean)*100.0))
       >> setField "sample2" (toString s2))
     |> Async.StartImmediate
-    //printfn "%s. f1 (%s) is ~%.0f%% faster than f2 (%s)." format (toString s1) ((1.0-s1.mean/s2.mean)*100.0) (toString s2)
 
 /// Expects function `f1` is faster than `f2`. Statistical test to 99.99%
 /// confidence level.

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -235,24 +235,24 @@ let containsAll (actual : _ seq)
   |> Tests.failtest
 
 let inline private except (elementsToCheck: Map<_,uint32>) (elementsToContain: Map<_,uint32>) (isExcept: bool) =
-  let getMapValue (map: Map<_, uint32>) (element) = 
+  let getMapValue (map: Map<_, uint32>) (element) =
     map |> Map.find element
-  let getResult found expected = 
+  let getResult found expected =
     match isExcept with
     | true -> found, expected
     | _ -> expected, found
-  
+
   let noOfFoundElements element value =
     let foundElements = (getMapValue elementsToContain element)
     match value > foundElements with
     | true -> getResult foundElements value
     | _ -> 0ul,0ul
-  
-  let elementsWhichDiffer element value = 
+
+  let elementsWhichDiffer element value =
     match elementsToContain |> Map.containsKey(element) with
     | true -> noOfFoundElements element value
     | _ -> getResult 0ul value
-  
+
   let printResult found =
     sprintf "(%d/%d)" (fst found) (snd found)
 
@@ -266,7 +266,7 @@ let inline private except (elementsToCheck: Map<_,uint32>) (elementsToContain: M
 /// first element in every tuple from `expected` map means item which should be
 /// presented in `actual` sequence, the second element means an expected number of occurrences
 /// of this item in sequence.
-/// Function is not taking into account an order of elements. 
+/// Function is not taking into account an order of elements.
 /// Calling this function will enumerate both sequences; they have to be finite.
 let distribution (actual : _ seq)
                 (expected : Map<_,uint32>)
@@ -281,7 +281,7 @@ let distribution (actual : _ seq)
   let extra, missing =
     except groupedActual expected false,
     except expected groupedActual true
-  
+
   let isCorrect = List.isEmpty missing && List.isEmpty extra
   if isCorrect then () else
   let formatInput(data) = formatSet ", " "{%s}" "" data
@@ -434,12 +434,13 @@ let isFasterThanSub (f1:Performance.Measurer<_,_>->'a) (f2:Performance.Measurer<
     Tests.failtestf "%s. Expected f1 (%s) to be faster than f2 (%s) but is ~%.0f%% slower."
                     format (toString s1) (toString s2) ((s1.mean/s2.mean-1.0)*100.0)
   | Performance.MetricLessThan (s1,s2) ->
-    Impl.logger.info (
+    Impl.logger.infoWithBP (
       eventX "{message}. f1 ({sample1}) is {percent} faster than f2 ({sample2})."
       >> setField "message" format
       >> setField "sample1" (toString s1)
       >> setField "percent" (sprintf "~%.0f%%" ((1.0-s1.mean/s2.mean)*100.0))
       >> setField "sample2" (toString s2))
+    |> Async.StartImmediate
     //printfn "%s. f1 (%s) is ~%.0f%% faster than f2 (%s)." format (toString s1) ((1.0-s1.mean/s2.mean)*100.0) (toString s2)
 
 /// Expects function `f1` is faster than `f2`. Statistical test to 99.99%

--- a/Expecto/Expecto.fsproj
+++ b/Expecto/Expecto.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -52,7 +52,6 @@
       <Paket>True</Paket>
       <Link>paket-files/Facade.fs</Link>
     </Compile>
-    <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="Expecto.fs" />
     <Compile Include="Performance.fs" />
     <Compile Include="Expect.fs" />

--- a/Expecto/Expecto.fsproj
+++ b/Expecto/Expecto.fsproj
@@ -52,6 +52,7 @@
       <Paket>True</Paket>
       <Link>paket-files/Facade.fs</Link>
     </Compile>
+    <Compile Include="AssemblyVersionInfo.fs" />
     <Compile Include="Expecto.fs" />
     <Compile Include="Performance.fs" />
     <Compile Include="Expect.fs" />


### PR DESCRIPTION
Hopefully the style is ok.

I think for LF vs CRLF you need a .gitattributes file.

I think ultimately there must be a better way to handle sync/async logging. Needs to be able to be switched  from async flush to manual flush.