### PR TITLE
add Expect.floatClose with better accuracy test

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -688,14 +688,32 @@ let performance =
 let close =
   testList "floatClose" [
 
+    testCase "zero" <| fun _ ->
+      Expect.floatClose accVeryHigh 0.0 0.0 "zero"
+
     testCase "small" <| fun _ ->
-      Expect.floatClose accTo3figs 1.004 1.000 "small to 3 figs"
+      Expect.floatClose accLow 0.000001 0.0 "small"
 
     testCase "large" <| fun _ ->
-      Expect.floatClose accTo3figs 1004.0 1000.0 "large to 3 figs"
+      Expect.floatClose accLow 10004.0 10000.0 "large"
+
+    testCase "user" <| fun _ ->
+      Expect.floatClose {absolute=0.0; relative=1e-3}
+        10004.0 10000.0 "user"
 
     testCase "can fail" <| fun _ ->
       let test() =
-        Expect.floatClose accTo3figs 104.0 100.0 "can fail to 3 figs"
+        Expect.floatClose accLow 1004.0 1000.0 "can fail"
       assertTestFails (test, Normal)
+
+    testCase "nan fails" <| fun _ ->
+      let test() =
+        Expect.floatClose accLow nan 1.0 "nan fails"
+      assertTestFails (test, Normal)
+
+    testCase "inf fails" <| fun _ ->
+      let test() =
+        Expect.floatClose accLow infinity 1.0 "inf fails"
+      assertTestFails (test, Normal)
+
   ]

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -683,3 +683,19 @@ let performance =
                             "popcount 16 faster than 32 fails"
       assertTestFailsWithMsgContaining "slower" (test, Normal)
   ]
+
+[<Tests>]
+let close =
+  testList "floatClose" [
+
+    testCase "small" <| fun _ ->
+      Expect.floatClose accTo3figs 1.004 1.000 "small to 3 figs"
+
+    testCase "large" <| fun _ ->
+      Expect.floatClose accTo3figs 1004.0 1000.0 "large to 3 figs"
+
+    testCase "can fail" <| fun _ ->
+      let test() =
+        Expect.floatClose accTo3figs 104.0 100.0 "can fail to 3 figs"
+      assertTestFails (test, Normal)
+  ]

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -110,11 +110,12 @@ let isGreaterThan a b format =
 let isGreaterThanOrEqual a b format =
   if a >= b then ()
   else
-    Tests.failtestf "%s. Expected a (%A) to be greater than or equal to b (%A)"
+    Tests.failtestf "%s. Expected a (%A) to be greater than or equal to b (%A)."
                     format a b
 
 /// Expects `actual` and `expected` (that are both floats) to equal within a
 /// given `epsilon`.
+[<Obsolete "Please use the more general Expect.floatClose">]
 let floatEqual actual expected epsilon format =
   let epsilon = defaultArg epsilon 0.001
   if expected <= actual + epsilon && expected >= actual - epsilon then
@@ -126,14 +127,16 @@ let floatEqual actual expected epsilon format =
 /// Expects `actual` and `expected` (that are both floats) to be within a
 /// given `accuracy`.
 let floatClose accuracy actual expected format =
-  if Accuracy.areClose accuracy actual expected then
-    ()
-  else
+  if Double.IsInfinity actual then
+    Tests.failtestf "%s. Expected actual to not be infinity, but it was." format
+  elif Double.IsInfinity expected then
+    Tests.failtestf "%s. Expected expected to not be infinity, but it was." format
+  elif Accuracy.areClose accuracy actual expected |> not then
     Tests.failtestf
-      "%s. Difference was %g but was expected to be less than %g to meet accuracy (absolute=%g relative=%g)"
-      format (Accuracy.areCloseLhs actual expected)
-             (Accuracy.areCloseRhs accuracy actual expected)
-             accuracy.absolute accuracy.relative
+      "%s. Expected difference to be less than %g for accuracy {absolute=%g; relative=%g}, but was %g."
+      format (Accuracy.areCloseRhs accuracy actual expected)
+      accuracy.absolute accuracy.relative
+      (Accuracy.areCloseLhs actual expected)
 
 /// Expects the two values to equal each other.
 let inline equal (actual : 'a) (expected : 'a) format =
@@ -302,7 +305,7 @@ let distribution (actual : _ seq)
     |> Map.toList
     |> List.map (fun element -> sprintf "%A: %d" (fst element) (snd element))
 
-  let missingElementsInfo, extraElementsInfo = 
+  let missingElementsInfo, extraElementsInfo =
     let incorrectElementsInfo elements is direction =
       if List.isEmpty elements then ""
       else sprintf "\n\t%s elements %s `actual`:\n\t%s" is direction (formatResult elements)

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -1114,19 +1114,20 @@ module Tests =
 
 
 type Accuracy =
-    {
-        absolute: float
-        relative: float
-    }
+  {
+    absolute: float
+    relative: float
+  }
 
 [<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
 module Accuracy =
   let inline areCloseLhs a b = abs(a-b)
-  let inline areCloseRhs m a b = m.absolute + m.relative * (max (abs a) (abs b))
+  let inline areCloseRhs m a b = m.absolute + m.relative * max (abs a) (abs b)
   let inline areClose m a b = areCloseLhs a b <= areCloseRhs m a b
 
 [<AutoOpen>]
 module AccuracyAuto =
-  let accTo3figs = {absolute=1e-2; relative=1e-2}
-  let accTo6figs = {absolute=1e-5; relative=1e-5}
-  let accTo9figs = {absolute=1e-8; relative=1e-8}
+  let accLow = {absolute=1e-6; relative=1e-3}
+  let accMedium = {absolute=1e-8; relative=1e-5}
+  let accHigh = {absolute=1e-10; relative=1e-7}
+  let accVeryHigh = {absolute=1e-12; relative=1e-9}

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -1111,3 +1111,22 @@ module Tests =
     testFromThisAssembly ()
     |> Option.orDefault (TestList ([], Normal))
     |> runTestsWithArgs config args
+
+
+type Accuracy =
+    {
+        absolute: float
+        relative: float
+    }
+
+[<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
+module Accuracy =
+  let inline areCloseLhs a b = abs(a-b)
+  let inline areCloseRhs m a b = m.absolute + m.relative * (max (abs a) (abs b))
+  let inline areClose m a b = areCloseLhs a b <= areCloseRhs m a b
+
+[<AutoOpen>]
+module AccuracyAuto =
+  let accTo3figs = {absolute=1e-2; relative=1e-2}
+  let accTo6figs = {absolute=1e-5; relative=1e-5}
+  let accTo9figs = {absolute=1e-8; relative=1e-8}

--- a/README.md
+++ b/README.md
@@ -260,11 +260,17 @@ This module is your main entry-point when asserting.
  - `isLessThanOrEqual`
  - `isGreaterThan`
  - `isGreaterThanOrEqual`
- - `floatEqual`
  - `notEqual`
  - `isFalse`
  - `isTrue`
  - `sequenceEqual`
+ - `floatClose : Accuracy -> float -> float -> string -> unit` - Expect the
+   floats to be within the combined absolute and relative accuracy given by
+   `abs(a-b) <= absolute + relative * max (abs a) (abs b)`. Default accuracy
+   available are: `accLow = {absolute=1e-6; relative=1e-3}`,
+   `accMedium = {absolute=1e-8; relative=1e-5}`,
+   `accHigh = {absolute=1e-10; relative=1e-7}`,
+   `accVeryHigh = {absolute=1e-12; relative=1e-9}`.
  - `sequenceStarts` - Expect the sequence `subject` to start with `prefix`. If
    it does not then fail with `format` as an error message together with a
    description of `subject` and `prefix`.


### PR DESCRIPTION
@haf,

Here is something I find useful for your consideration. It allows you to compare floats that are either large or small by combining an absolute and relative accuracy.

Its along the lines of https://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.isclose.html but better :).

You may want to look to deprecate `Expect.floatEqual`