### PR TITLE
add a C# wrapper for convenience

### DIFF
--- a/Expecto.CSharp/Expecto.CSharp.csproj
+++ b/Expecto.CSharp/Expecto.CSharp.csproj
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F4BF5A2F-5C3E-4596-AC72-01D16994BF9C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Expecto.CSharp</RootNamespace>
+    <AssemblyName>Expecto.CSharp</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Expecto">
+      <HintPath>..\Expecto\bin\Debug\Expecto.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Wrapper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="paket.references" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\net20\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+wp8\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile47')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+sl5+netcore45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/Expecto.CSharp/Properties/AssemblyInfo.cs
+++ b/Expecto.CSharp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Expecto.CSharp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Expecto.CSharp")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f4bf5a2f-5c3e-4596-ac72-01d16994bf9c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Expecto.CSharp/Wrapper.cs
+++ b/Expecto.CSharp/Wrapper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Expecto;
+using static Expecto.Impl;
+using Microsoft.FSharp.Core;
+using Microsoft.FSharp.Collections;
+
+namespace FSharpConverter
+{
+    public static class ToFSharpFuncConverterExtensions
+    {
+        private static readonly Unit Unit = (Unit)Activator.CreateInstance(typeof(Unit), true);
+        public static Func<Unit, Unit> ToFunc(this Action action) => x => {action(); return Unit; };
+        public static Func<T, Unit> ToFunc<T>(this Action<T> action) => x => { action(x); return Unit; };
+        public static FSharpFunc<T, Unit> ToFSharpFunc<T>(this Action<T> action) => FSharpFunc<T, Unit>.FromConverter(new Converter<T, Unit>(action.ToFunc()));
+        public static FSharpFunc<Unit, Unit> ToFSharpFunc(this Action action) => FSharpFunc<Unit, Unit>.FromConverter(new Converter<Unit, Unit>(action.ToFunc()));
+    }
+}
+
+namespace Expecto
+{
+    using FSharpConverter;
+
+    public static class CSharp
+    {
+        public static int RunTests(ExpectoConfig config, Test tests) => runEval(config, tests);
+        public static int RunTestsWithArgs(ExpectoConfig config, string[] args, Test tests) => Tests.runTestsWithArgs(config, args, tests);
+        public static int RunTestsInAssembly(ExpectoConfig config, string[] args) => Tests.runTestsInAssembly(config, args);
+        public static void ListTests(Test tests) => Tests.listTests(tests);
+        public static Test TestList(string name, IEnumerable<Test> tests) => Tests.testList(name, ListModule.OfSeq(tests));
+        public static Test TestCase(string name, Action test) => Tests.testCase(name, test.ToFSharpFunc());
+        public static Test TestCase(string name, Task test) => Tests.testCaseAsync(name, Async.awaitTask(test));
+        public static Test PendingTestCase(string name, Action test) => Tests.ptestCase(name, test.ToFSharpFunc());
+        public static Test PendingTestCase(string name, Task test) => Tests.ptestCaseAsync(name, Async.awaitTask(test));
+        public static Test FocusedTestCase(string name, Action test) => Tests.ftestCase(name, test.ToFSharpFunc());
+        public static Test FocusedTestCase(string name, Task test) => Tests.ftestCaseAsync(name, Async.awaitTask(test));
+        public static ExpectoConfig DefaultConfig => Tests.defaultConfig;
+    }
+}

--- a/Expecto.CSharp/paket.references
+++ b/Expecto.CSharp/paket.references
@@ -1,0 +1,1 @@
+FSharp.Core

--- a/Expecto.Sample/App.config
+++ b/Expecto.Sample/App.config
@@ -1,6 +1,27 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
-</configuration>
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.3.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.2.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.4.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.0.0" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/Expecto.Tests.CSharp/Expecto.Tests.CSharp.csproj
+++ b/Expecto.Tests.CSharp/Expecto.Tests.CSharp.csproj
@@ -1,0 +1,139 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{87E8FA7E-C2C8-488C-9B8F-7B887EDF5E4B}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Expecto.Tests.CSharp</RootNamespace>
+    <AssemblyName>Expecto.Tests.CSharp</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Tests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Expecto.CSharp\Expecto.CSharp.csproj">
+      <Project>{f4bf5a2f-5c3e-4596-ac72-01d16994bf9c}</Project>
+      <Name>Expecto.CSharp</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Expecto\Expecto.fsproj">
+      <Project>{c0d55728-10a9-4a7a-9df9-d2f21f663ac2}</Project>
+      <Name>Expecto</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="paket.references" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\net20\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch') Or ($(TargetFrameworkIdentifier) == 'Xamarin.iOS')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+monoandroid10+monotouch10+xamarinios10\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.1' Or $(TargetFrameworkVersion) == 'v1.2' Or $(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile44')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And $(TargetFrameworkVersion) == 'v1.0') Or ($(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')) Or ($(TargetFrameworkProfile) == 'Profile31') Or ($(TargetFrameworkProfile) == 'Profile49') Or ($(TargetFrameworkProfile) == 'Profile78')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+wp8\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile84') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151') Or ($(TargetFrameworkProfile) == 'Profile157') Or ($(TargetFrameworkProfile) == 'Profile259')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0') Or ($(TargetFrameworkProfile) == 'Profile24') Or ($(TargetFrameworkProfile) == 'Profile47')">
+      <ItemGroup>
+        <Reference Include="FSharp.Core">
+          <HintPath>..\packages\FSharp.Core\lib\portable-net45+sl5+netcore45\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+</Project>

--- a/Expecto.Tests.CSharp/Properties/AssemblyInfo.cs
+++ b/Expecto.Tests.CSharp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Expecto.Tests.CSharp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Expecto.Tests.CSharp")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("87e8fa7e-c2c8-488c-9b8f-7b887edf5e4b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Expecto.Tests.CSharp/Tests.cs
+++ b/Expecto.Tests.CSharp/Tests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using static Expecto.CSharp;
+
+namespace Expecto.Tests.CSharp
+{
+    public class Samples
+    {
+        [Tests]
+        public static Test blah =
+            TestList("general groupings", new[] {
+                TestCase("standard", () => Console.Write("standard")),
+                TestCase("standard async", async () => {
+                    await Task.Delay(100);
+                    Console.Write("standard task");
+                }),
+                PendingTestCase("pending", () => Console.Write("pending")),
+                PendingTestCase("pending async", async () => {
+                    await Task.Delay(100);
+                    Console.Write("standard task");
+                }),
+                FocusedTestCase("focused", () => Console.Write("focused")),
+                FocusedTestCase("focused async", async () => {
+                    await Task.Delay(100);
+                    Console.Write("standard task");
+                }),
+            });
+
+        public static int Main(string[] argv) => RunTestsInAssembly(DefaultConfig, argv);    
+    }
+}

--- a/Expecto.Tests.CSharp/app.config
+++ b/Expecto.Tests.CSharp/app.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup><runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.3.1.0" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/Expecto.Tests.CSharp/paket.references
+++ b/Expecto.Tests.CSharp/paket.references
@@ -1,0 +1,1 @@
+FSharp.Core

--- a/Expecto.Tests/app.config
+++ b/Expecto.Tests/app.config
@@ -1,4 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   
-</configuration>
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.3.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.2.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.4.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.0.0" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/Expecto.sln
+++ b/Expecto.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{3786E131-11FB-4606-AFE0-5E6CDA744DD0}"
 	ProjectSection(SolutionItems) = preProject
@@ -39,6 +39,10 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Expecto.Tests", "Expecto.Te
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Expecto.Sample", "Expecto.Sample\Expecto.Sample.fsproj", "{9996E3A7-F97F-4A6A-AD5F-C6C70858E220}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Expecto.Tests.CSharp", "Expecto.Tests.CSharp\Expecto.Tests.CSharp.csproj", "{87E8FA7E-C2C8-488C-9B8F-7B887EDF5E4B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Expecto.CSharp", "Expecto.CSharp\Expecto.CSharp.csproj", "{F4BF5A2F-5C3E-4596-AC72-01D16994BF9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +69,14 @@ Global
 		{9996E3A7-F97F-4A6A-AD5F-C6C70858E220}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9996E3A7-F97F-4A6A-AD5F-C6C70858E220}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9996E3A7-F97F-4A6A-AD5F-C6C70858E220}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87E8FA7E-C2C8-488C-9B8F-7B887EDF5E4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87E8FA7E-C2C8-488C-9B8F-7B887EDF5E4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87E8FA7E-C2C8-488C-9B8F-7B887EDF5E4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87E8FA7E-C2C8-488C-9B8F-7B887EDF5E4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4BF5A2F-5C3E-4596-AC72-01D16994BF9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4BF5A2F-5C3E-4596-AC72-01D16994BF9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4BF5A2F-5C3E-4596-AC72-01D16994BF9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4BF5A2F-5C3E-4596-AC72-01D16994BF9C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,5 +84,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{4182E778-F6C2-4BA4-BFC7-19DB54890E18} = {5B9D0E5F-378A-4310-B9F3-4ECF67AA5A23}
 		{9996E3A7-F97F-4A6A-AD5F-C6C70858E220} = {191A316D-EA59-4BA9-9A70-D2AC46ECC6ED}
+		{87E8FA7E-C2C8-488C-9B8F-7B887EDF5E4B} = {5B9D0E5F-378A-4310-B9F3-4ECF67AA5A23}
 	EndGlobalSection
 EndGlobal

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -83,6 +83,8 @@ module Async =
       return fn v
     }
 
+  let awaitTask (t : System.Threading.Tasks.Task) = t |> (Async.AwaitIAsyncResult >> Async.Ignore)
+
   let bind fn a =
     async.Bind(a, fn)
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,6 +3,8 @@ source https://dotnet.myget.org/F/dotnet-core
 source https://www.myget.org/F/fsharp-daily
 source https://www.myget.org/F/netcorecli-fsc-preview3
 
+redirects: on
+
 github logary/logary src/Logary.Facade/Facade.fs 4b21d888e83d72d1238ab0f36110e2a3946240e7
 
 nuget Argu

--- a/paket.lock
+++ b/paket.lock
@@ -1,3 +1,4 @@
+REDIRECTS: ON
 NUGET
   remote: https://www.nuget.org/api/v2
     Argu (3.2)


### PR DESCRIPTION
This adds a new project for authoring a C# wrapper that handles nice interop around `IEnumerable<Test>` instead of `Test list` and `Task` instead of `Async<unit>` for our C# friends.  There is also a small sample test project to verify that things work.

Is this valued? If so, what needs to be done at this point to author packages?