### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,11 @@ environment:
   matrix:
     - CLI_VERSION: 1.0.0-preview3-003857
 
+install:
+  - bundle install
+
 build_script:  
+  - bundle exec rake
 
   # .NET Core SDK binaries
   - ps: $url = "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/rel-1.0.0/dotnet-dev-win-x64.latest.zip"


### PR DESCRIPTION
@haf

Here is the appveyor.yml showing the fails I see.

Later today I'll finish off a some changes to assertTestFails that make it into a test that just runs with the others. This eliminates the contention and means parallel-workers could also have an unlimited option.

As part of that I will probably fix the failing tests anyway. I think it's multi line strings putting in CRLF on windows that's causing it.

You can merge this or wait for my update later.

