### PR TITLE
minor --version bug fix and paket.local support

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -73,7 +73,7 @@ Target "DotnetBuild" (fun _ ->
   dotnet "build"   netcoreDir
 )
 
-Target "NuGet" (fun _ ->
+Target "CreateNuGets" (fun _ ->
   let result =
     ExecProcess (fun info ->
       info.FileName <- "cmd"

--- a/build.fsx
+++ b/build.fsx
@@ -73,6 +73,14 @@ Target "DotnetBuild" (fun _ ->
   dotnet "build"   netcoreDir
 )
 
+Target "NuGet" (fun _ ->
+  let result =
+    ExecProcess (fun info ->
+      info.FileName <- "cmd"
+      info.Arguments <- "/c bundle exec rake create_nugets"
+    ) (TimeSpan.FromMinutes 5.0)
+  if result <> 0 then failwithf "NuGet fail"
+)
 
 // --------------------------------------------------------------------------------------
 // Target Dependencies


### PR DESCRIPTION
Spotted a bug with the printing of version getting mixed up while using Expecto.

Also add FAKE Target to make paket.local easy as follows:

nuget Expecto -> git file:///C:\Users\Ant\src\expecto master build:"build.cmd CreateNuGets", Packages: /build/pkg/