### PR TITLE
fixed typo in first example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ open Expecto
 
 let tests =
   test "A simple test" {
-    let subject = "Hello world"
+    let subject = "Hello World"
     Expect.equal subject "Hello World" "The strings should equal"
   }
 


### PR DESCRIPTION
Small typo, which leads to an exception, because "Hello **w**orld" is not equal to "Hello **W**orld".
-->  Expecto.AssertException: The string should equal.