### PR TITLE
Add isOk and isError expectations

### DIFF
--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -73,6 +73,20 @@ let isChoice2Of2 x message =
   | Choice2Of2 _ ->
     ()
 
+/// Expects the value to be a Result.Ok value.
+let isOk x message =
+  match x with
+  | Result.Ok _ -> ()
+  | Result.Error x ->
+    Tests.failtestf "%s. Expected Ok, was Error(%A)." message x
+
+/// Expects the value to be a Result.Error value.
+let isError x message =
+  match x with
+  | Result.Ok x ->
+    Tests.failtestf "%s. Expected Error _, was Ok(%A)." message x
+  | Result.Error _ -> ()
+
 /// Expects the value not to be null.
 let isNotNull x message =
   match x with

--- a/Expecto/Flip.Expect.fs
+++ b/Expecto/Flip.Expect.fs
@@ -21,6 +21,12 @@ let inline isChoice1Of2 message x = Expecto.Expect.isChoice1Of2 x message
 /// Expects the value to be a Choice2Of2 value.
 let inline isChoice2Of2 message x = Expecto.Expect.isChoice2Of2 x message
 
+/// Expects the value to be a Result.Ok value.
+let inline isOk message x = Expecto.Expect.isOk x message
+
+/// Expects the value to be a Result.Error value.
+let inline isError message x = Expecto.Expect.isError x message
+
 /// Expects the value not to be null.
 let inline isNotNull message x = Expecto.Expect.isNotNull x message
 

--- a/README.md
+++ b/README.md
@@ -578,6 +578,8 @@ This module is your main entry-point when asserting.
 - `isSome`
 - `isChoice1Of2`
 - `isChoice2Of2`
+- `isOk` - Expect the value to be a Result.Ok value
+- `isError` - Expect the value to be a Result.Error value
 - `isNull`
 - `isNotNull`
 - `isNotNaN`


### PR DESCRIPTION
These test the Result type from F# 4.1, so they will only be available in Expecto versions 5.x and above.

This will fix #62.