### PR TITLE
#156 add exists function

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -659,6 +659,19 @@ let expecto =
         ) |> assertTestFails
       ]
 
+      testList "#all" [
+        testCase "pass" <| fun _ ->
+          Expect.all [2;2] ((=) 2) "should pass"
+
+        testCase "fail" (fun _ ->
+          Expect.all [2;3] ((=) 2) "should fail"
+        ) |> assertTestFails
+
+        testCase "null" (fun _ ->
+          Expect.all null ((=) 5) "should also fail"
+        ) |> assertTestFails
+      ]
+
       testList "#containsAll" [
         testCase "identical sequence" <| fun _ ->
           Expect.containsAll [|21;37|] [|21;37|] "Identical"

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -646,6 +646,19 @@ let expecto =
         ) |> assertTestFails
       ]
 
+      testList "#exists" [
+        testCase "pass" <| fun _ ->
+          Expect.exists [2;2;4] ((=) 2) "should pass"
+
+        testCase "fail" (fun _ ->
+          Expect.exists [2;3] ((=) 5) "should fail"
+        ) |> assertTestFails
+
+        testCase "null" (fun _ ->
+          Expect.exists null ((=) 5) "should also fail"
+        ) |> assertTestFails
+      ]
+
       testList "#containsAll" [
         testCase "identical sequence" <| fun _ ->
           Expect.containsAll [|21;37|] [|21;37|] "Identical"

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -302,7 +302,7 @@ let all ( actual: 'a seq) asserter message =
   | _ ->
     let checkResult = checkThem
     if checkResult |> Seq.isEmpty then ()
-    else Tests.failtestf "%s. Some elements doesn't satisfy `asserter`.\n%s" message (formatResult checkResult)
+    else Tests.failtestf "%s. Some elements don't satisfy `asserter`.\n%s" message (formatResult checkResult)
 
 /// Expects the `sequence` to contain the `element`.
 let contains sequence element message =

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -275,6 +275,16 @@ let isTrue actual message =
   else
     Tests.failtestf "%s. Actual value was false but had expected it to be true." message
 
+/// Expect that some element from `actual` satisfies the given `asserter`
+let exists ( actual: 'a seq) asserter message =
+  let exist = 
+    match actual with
+    | null -> false
+    | _ -> actual |> Seq.exists asserter
+  if exist then ()
+  else Tests.failtestf "%s. There isn't any element which satisfies given assertion %A." message asserter
+
+
 /// Expects the `sequence` to contain the `element`.
 let contains sequence element message =
   match sequence |> Seq.tryFind ((=) element) with

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -284,6 +284,25 @@ let exists ( actual: 'a seq) asserter message =
   if exist then ()
   else Tests.failtestf "%s. There isn't any element which satisfies given assertion %A." message asserter
 
+/// Expect that all elements from `actual` satisfies the given `asserter`
+let all ( actual: 'a seq) asserter message =
+  let checkThem =
+      seq { for i in 0..(actual |> Seq.length) - 1 do
+            let isDifferent = Seq.item i actual |> asserter |> not
+            if isDifferent then yield (i, sprintf "%A" (Seq.item i actual))
+      }
+
+  let formatResult result =
+    result
+    |> Seq.map ( fun x -> sprintf "Element at index: %d which is equal to: %A" (fst x) (snd x))
+    |> String.concat "\n"
+
+  match actual with
+  | null -> Tests.failtestf "%s. Sequence is empty" message
+  | _ ->
+    let checkResult = checkThem
+    if checkResult |> Seq.isEmpty then ()
+    else Tests.failtestf "%s. Some elements doesn't satisfy `asserter`.\n%s" message (formatResult checkResult)
 
 /// Expects the `sequence` to contain the `element`.
 let contains sequence element message =

--- a/Expecto/Flip.Expect.fs
+++ b/Expecto/Flip.Expect.fs
@@ -100,6 +100,9 @@ let inline isFalse message actual = Expecto.Expect.isFalse actual message
 /// Expects the value to be true.
 let inline isTrue message actual = Expecto.Expect.isTrue actual message
 
+/// Expect that some element from `actual` satisfies the given `asserter`
+let inline exists message asserter actual = Expecto.Expect.exists actual asserter message
+
 /// Expects the `sequence` to contain the `element`.
 let inline contains message element sequence = Expecto.Expect.contains sequence element message
 

--- a/Expecto/Flip.Expect.fs
+++ b/Expecto/Flip.Expect.fs
@@ -103,6 +103,9 @@ let inline isTrue message actual = Expecto.Expect.isTrue actual message
 /// Expect that some element from `actual` satisfies the given `asserter`
 let inline exists message asserter actual = Expecto.Expect.exists actual asserter message
 
+/// Expect that all elements from `actual` satisfies the given `asserter`
+let inline all message asserter actual = Expecto.Expect.all actual asserter message
+
 /// Expects the `sequence` to contain the `element`.
 let inline contains message element sequence = Expecto.Expect.contains sequence element message
 

--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ This module is your main entry-point when asserting.
 - `isFalse`
 - `isTrue`
 - `exists` - Expect that some element from `actual` sequence satisfies the given `asserter`
+- `all` - Expect that all elements from `actual` satisfies the given `asserter`
 - `sequenceEqual`
 - `floatClose : Accuracy -> float -> float -> string -> unit` - Expect the
    floats to be within the combined absolute and relative accuracy given by

--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ This module is your main entry-point when asserting.
 - `notEqual`
 - `isFalse`
 - `isTrue`
+- `exists` - Expect that some element from `actual` sequence satisfies the given `asserter`
 - `sequenceEqual`
 - `floatClose : Accuracy -> float -> float -> string -> unit` - Expect the
    floats to be within the combined absolute and relative accuracy given by


### PR DESCRIPTION
#156 
`exists` function. 
`all` function, without `delta/diff function`
Error msg for `all` looks like this:
![image](https://cloud.githubusercontent.com/assets/7689103/26010049/ac02fc20-374b-11e7-955b-030611e50df4.png)
Is it ok? When `delta/diff function` would be implemented it could be changed to `Element at index %d which is equal to %A, has following difference %A"?
CC: @haf 