### PR TITLE
Use Seq/List item instead of Seq/List nth

### DIFF
--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -315,7 +315,7 @@ let inline private formatSet<'a> (concatBy) (formatResult) (whenEmpty) (ss : 'a 
   if Seq.isEmpty ss then
     whenEmpty
   else
-    (match box (Seq.nth 0 ss) with
+    (match box (Seq.item 0 ss) with
     | :? IComparable ->
       ss
       |> Seq.cast<IComparable>

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -1031,7 +1031,7 @@ module Impl =
 
       let randNext tests =
         let next = List.length tests |> rand.Next
-        List.nth tests next
+        List.item next tests
 
       let finishTimestamp =
         lazy

--- a/Expecto/Performance.fs
+++ b/Expecto/Performance.fs
@@ -81,8 +81,8 @@ module Performance =
 
       let s1,s2,precision =
         let seq = Seq.zip3 (stats f1) (stats f2) (stats (fun m -> m (fun () -> Unchecked.defaultof<_>) ()))
-        Seq.nth 2 seq |> ignore
-        Seq.nth 5 seq
+        Seq.item 2 seq |> ignore
+        Seq.item 5 seq
 
       if max s1.mean s2.mean < precision.mean * 5.0 then
         MetricTooShort ((if s1.mean<s2.mean then s2 else s1),precision)


### PR DESCRIPTION
Remove all usages of List/Seq nth and replace them by List/Seq item since nth is deprecated.
So we don't see these warnings:
![image](https://cloud.githubusercontent.com/assets/7689103/26025404/01292968-37e7-11e7-8181-42bfd1de1183.png)

`Note: In F# 3.x, nth is defined with inconsistent signatures for Array and List. The proposal above replaces nth by item and would eventually deprecate nth (with a message to say 'please use Seq.item'. It also adds a corresponding tryItem. Both item and tryItem would take the integer index as the first parameter.` [source](https://visualfsharp.codeplex.com/wikipage?title=Status)

CC: @haf 