### PR TITLE
Expect.throws should fail when exception is not raised

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -451,7 +451,45 @@ let expecto =
         ) |> assertTestFails
       ]
 
-      testList "raise" [
+      testList "throws" [
+
+        testCase "pass" <| fun _ ->
+          Expect.throws (fun _ -> nullArg "") "Expected to throw an exception"
+
+        testCase "fail when exception is not raised" (fun _ ->
+          Expect.throws ignore "Should fail because no exception is thrown"
+        ) |> assertTestFails
+      ]
+
+      testList "throwsC" [
+
+        testCase "pass and call 'cont' when exception is raised" <| fun _ ->
+          let mutable contCalled = false
+          let exc = Exception()
+          Expect.throwsC
+            (fun _ -> raise exc)
+            (fun e ->
+              contCalled <- true
+              if e <> exc then failtest "passes different exception"
+            )
+
+          if not contCalled then failtest "'cont' is not called"
+
+        testCase "fail when exception is not raised" (fun _ ->
+          Expect.throwsC ignore ignore
+        ) |> assertTestFails
+
+        testCase "do not call 'cont' if exception is not raised" <| fun _ ->
+          let mutable contCalled = false
+          try
+            Expect.throwsC ignore (fun e -> contCalled <- true)
+          with
+            _ -> ()
+
+          if contCalled then failtest "should not call 'cont'"
+      ]
+
+      testList "throwsT" [
 
         testCase "pass" <| fun _ ->
           Expect.throwsT<ArgumentNullException> (fun _ -> nullArg "")

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -11,19 +11,27 @@ open Expecto.Logging.Message
 
 /// Expects f to throw an exception.
 let throws f message =
-  try
-    f ()
-    Tests.failtestf "%s. Expected f to throw." message
-  with e ->
-    ()
+  let thrown =
+    try
+      f ()
+      false
+    with _ ->
+      true
+
+  if not thrown then Tests.failtestf "%s. Expected f to throw." message
 
 /// Expects f to throw, and calls `cont` with its exception.
 let throwsC f cont =
-  try
-    f ()
-    Tests.failtest "Expected f to throw."
-  with e ->
-    cont e
+  let thrown =
+    try
+      f ()
+      None
+    with e ->
+      Some e
+
+  match thrown with
+  | Some e -> cont e
+  | _ -> Tests.failtestf "Expected f to throw."
 
 /// Expects the passed function to throw `'texn`.
 let throwsT<'texn> f message =
@@ -38,7 +46,6 @@ let throwsT<'texn> f message =
                     (e.GetType().FullName)
   | e ->
     ()
-
 
 /// Expects the value to be a None value.
 let isNone x message =


### PR DESCRIPTION
Hello, please review this PR.
It seems that now ```Expect.throws``` does not fail test when exception is not raised