### PR TITLE
add Func<Task> overloads to the C# api

### DIFF
--- a/Expecto.Tests.CSharp/Tests.cs
+++ b/Expecto.Tests.CSharp/Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Expecto.CSharp;
 using Expecto;
@@ -27,6 +27,20 @@ namespace Test.CSharp
                 }),
             });
 
-		public static int Main(string[] argv) => Runner.RunTestsInAssembly(Runner.DefaultConfig, argv);
+        [Tests]
+        public static Expecto.Test failingTests =
+            Runner.TestList("general groupings", new Expecto.Test[] {
+                Runner.TestCase("async Action", async () => {
+                    await Task.FromException(new Exception("FAIL"));
+                }),
+                Runner.PendingTestCase("pending async Action", async () => {
+                    await Task.FromException(new Exception("FAIL"));
+                }),
+                Runner.FocusedTestCase("focused async Action", async () => {
+                    await Task.FromException(new Exception("FAIL"));
+                })
+            });
+
+        public static int Main(string[] argv) => Runner.RunTestsInAssembly(Runner.DefaultConfig, argv);
     }
 }

--- a/Expecto.Tests.CSharp/Tests.cs
+++ b/Expecto.Tests.CSharp/Tests.cs
@@ -25,19 +25,17 @@ namespace Test.CSharp
                     await Task.Delay(100);
                     Console.Write("standard task");
                 }),
-            });
-
-        [Tests]
-        public static Expecto.Test failingTests =
-            Runner.TestList("general groupings", new Expecto.Test[] {
                 Runner.TestCase("async Action", async () => {
-                    await Task.FromException(new Exception("FAIL"));
+                    await Task.Delay(100);
+                    Console.Write("task");
                 }),
                 Runner.PendingTestCase("pending async Action", async () => {
-                    await Task.FromException(new Exception("FAIL"));
+                    await Task.Delay(100);
+                    Console.Write("task");
                 }),
                 Runner.FocusedTestCase("focused async Action", async () => {
-                    await Task.FromException(new Exception("FAIL"));
+                    await Task.Delay(100);
+                    Console.Write("task");
                 })
             });
 

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -1667,12 +1667,18 @@ module Runner =
   let TestCaseA(name, test: System.Action) = testCase name test.Invoke
   [<CompiledName("TestCase")>]
   let TestCaseT(name, test: Task) = testCaseAsync name (Async.AwaitTask test)
+  [<CompiledName("TestCase")>]
+  let TestCaseFT(name, test: System.Func<Task>) = testCaseAsync name (async { do! Async.AwaitTask (test.Invoke()) })
   [<CompiledName("PendingTestCase")>]
   let PendingTestCaseA(name, test: System.Action) = ptestCase name test.Invoke
   [<CompiledName("PendingTestCase")>]
   let PendingTestCaseT(name, test: Task) = ptestCaseAsync name (Async.AwaitTask test)
+  [<CompiledName("PendingTestCase")>]
+  let PendingTestCaseFT(name, test: System.Func<Task>) = ptestCaseAsync name (async { do! Async.AwaitTask (test.Invoke()) })
   [<CompiledName("FocusedTestCase")>]
   let FocusedTestCaseA(name, test: System.Action) = ftestCase name test.Invoke
   [<CompiledName("FocusedTestCase")>]
   let FocusedTestCaseT(name, test: Task) = ftestCaseAsync name (Async.AwaitTask test)
+  [<CompiledName("FocusedTestCase")>]
+  let FocusedTestCaseFT(name, test: System.Func<Task>) = ftestCaseAsync name (async { do! Async.AwaitTask (test.Invoke()) })
   let DefaultConfig = defaultConfig


### PR DESCRIPTION
Reason:

The following code compiles and runs, but does not what I expected it to:

```C#
        [FTests]
        public static Test blah =
            Runner.TestList("Test", new[]{ Runner.TestCase("TestCase", async () =>
            {
                await Task.FromException(new Exception("FAIL"));
            })});
```

![image](https://user-images.githubusercontent.com/4236651/28967519-c16fdbe8-791b-11e7-80ae-fda3fc5f75b6.png)

It used the ``Action`` overload, so the exception is thrown on the threadpool, where no-one cares.

Now it _should_ prefer the ``Func<Task>`` overload and correctly fail the test.

Note: I can't build it locally, so let's see what the CI says.