### PR TITLE
fixes #191

### DIFF
--- a/Expecto.netcore/Expecto.netcore.fsproj
+++ b/Expecto.netcore/Expecto.netcore.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="..\Expecto\Performance.fs" />
     <Compile Include="..\Expecto\Expecto.fs" />
     <Compile Include="..\Expecto\Expect.fs" />
+    <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />


### PR DESCRIPTION
Verified that the build does the expected thing on MacOS.  Fixes #191 

```
3:17 $ monodis --assembly Expecto.dll
Assembly Table
Name:          Expecto
Hash Algoritm: 0x00008004
Version:       5.0.0.0
Flags:         0x00000000
PublicKey:     BlobPtr (0x00000000)
	Zero sized public key
Culture:
```
