### PR TITLE
Add Expecto.Flip.Expect module to .NET Standard version

### DIFF
--- a/Expecto.netcore/Expecto.netcore.fsproj
+++ b/Expecto.netcore/Expecto.netcore.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="..\Expecto\Performance.fs" />
     <Compile Include="..\Expecto\Expecto.fs" />
     <Compile Include="..\Expecto\Expect.fs" />
+    <Compile Include="..\Expecto\Flip.Expect.fs" />
     <Compile Include="AssemblyVersionInfo.fs" Condition="Exists('AssemblyVersionInfo.fs')" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The `Expecto.Flip.Expect` module is missing in the .NET Standard version.