### PR TITLE
ExpectoConfig: add C# compatible With* methods / Logging: add Task based Interface

### DIFF
--- a/Expecto.Tests.CSharp/Tests.cs
+++ b/Expecto.Tests.CSharp/Tests.cs
@@ -2,9 +2,53 @@ using System;
 using System.Threading.Tasks;
 using Expecto.CSharp;
 using Expecto;
+using static Expecto.Impl;
 
 namespace Test.CSharp
 {
+    public class CSharpPrinter : ITestPrinter
+    {
+        Task ITestPrinter.BeforeEach(string value)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ITestPrinter.BeforeRun(Expecto.Test value)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ITestPrinter.Exn(string value1, Exception value2, TimeSpan value3)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ITestPrinter.Failed(string value1, string value2, TimeSpan value3)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ITestPrinter.Ignored(string value1, string value2)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ITestPrinter.Info(string value)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ITestPrinter.Passed(string value1, TimeSpan value2)
+        {
+            return Task.CompletedTask;
+        }
+
+        Task ITestPrinter.Summary(ExpectoConfig value1, TestRunSummary value2)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
     public class Samples
     {
         [Tests]
@@ -39,6 +83,6 @@ namespace Test.CSharp
                 })
             });
 
-        public static int Main(string[] argv) => Runner.RunTestsInAssembly(Runner.DefaultConfig, argv);
+        public static int Main(string[] argv) => Runner.RunTestsInAssembly(Runner.DefaultConfig.WithMySpiritIsWeak(false).AddPrinter(new CSharpPrinter()), argv);
     }
 }

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -1769,18 +1769,17 @@ type ITestPrinter =
 
 [<AutoOpen; Extension>]
 module Runner =
-  open Expecto
   open System.Collections.Generic
 
   let private printerFromInterface (i : ITestPrinter) =
-      { beforeRun   = i.BeforeRun >> Async.AwaitTask
-        beforeEach  = i.BeforeEach >> Async.AwaitTask
-        passed      = fun n d -> i.Passed(n, d) |> Async.AwaitTask
-        info        = i.Info >> Async.AwaitTask
-        ignored     = fun n m -> i.Ignored(n, m) |> Async.AwaitTask
-        failed      = fun n m d -> i.Failed(n, m, d) |> Async.AwaitTask
-        exn         = fun n e d -> i.Exn(n, e, d) |> Async.AwaitTask
-        summary     = fun c s -> i.Summary(c, s) |> Async.AwaitTask
+      { beforeRun   = fun t ->      async { return! i.BeforeRun(t) |> Async.AwaitTask }
+        beforeEach  = fun s ->      async { return! i.BeforeEach(s) |> Async.AwaitTask }
+        passed      = fun n d ->    async { return! i.Passed(n, d) |> Async.AwaitTask }
+        info        = fun s ->      async { return! i.Info(s) |> Async.AwaitTask }
+        ignored     = fun n m ->    async { return! i.Ignored(n, m) |> Async.AwaitTask }
+        failed      = fun n m d ->  async { return! i.Failed(n, m, d) |> Async.AwaitTask }
+        exn         = fun n e d ->  async { return! i.Exn(n, e, d) |> Async.AwaitTask }
+        summary     = fun c s ->    async { return! i.Summary(c, s) |> Async.AwaitTask }
       }
 
   type Async with

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -816,7 +816,7 @@ module Impl =
           do! innerPrinter.summary c s
           tcLog "testSuiteFinished" [
             "name", "ExpectoTestSuite" ] } }
-    static member mergePrinters (first:TestPrinters, second:TestPrinters) =
+    static member internal mergePrinters (first:TestPrinters, second:TestPrinters) =
       let runTwoAsyncs a b = async {
         do! a
         do! b


### PR DESCRIPTION
As the C# sample project shows, it is already possible without too much fuzz to define Tests in C#.

But without the F# ``with`` expression, it is actually pretty hard to update the config.

This adds .With* methods, and also adds a way for C# code to define a Printer.