### PR TITLE
unwrap AggregateExceptions with a single inner exception

### DIFF
--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -952,6 +952,10 @@ module Impl =
           w.Stop()
           return
             TestSummary.single (Ignored e.Message) (float w.ElapsedMilliseconds)
+        | :? AggregateException as e when e.InnerExceptions.Count = 1 ->
+          w.Stop()
+          return
+            TestSummary.single (TestResult.Error e.InnerException) (float w.ElapsedMilliseconds)
         | e ->
           w.Stop()
           return


### PR DESCRIPTION
fixes https://github.com/haf/expecto/issues/269

after:

![grafik](https://user-images.githubusercontent.com/4236651/43632937-ed6b8098-9707-11e8-8d9a-8064a52fe601.png)
