### PR TITLE
Fix `throwsT` message on no exception.

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -506,6 +506,10 @@ let expecto =
           Expect.throwsT<ArgumentNullException> ignore "Ignore 'should' throw an exn, ;)"
         ) |> assertTestFails
 
+        testCase "give correct assert message on no exception" (fun _ ->
+          Expect.throwsT<ArgumentNullException> ignore "Should throw null arg"
+        ) |> assertTestFailsWithMsgContaining "Expected f to throw."
+
       ]
 
       testList "flipped throwsT" [

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -36,17 +36,20 @@ let throwsC f cont =
 
 /// Expects the passed function to throw `'texn`.
 let throwsT<'texn> f message =
-  try
-    f ()
-    Tests.failtestf "%s. Expected f to throw." message
-  with
-  | e when e.GetType() <> typeof<'texn> ->
+  let thrown =
+    try
+      f ()
+      None
+    with e ->
+      Some e
+  match thrown with
+  | Some e when e.GetType() <> typeof<'texn> ->
     Tests.failtestf "%s. Expected f to throw an exn of type %s, but one of type %s was thrown."
                     message
                     (typeof<'texn>.FullName)
                     (e.GetType().FullName)
-  | e ->
-    ()
+  | Some _ -> ()
+  | _ -> Tests.failtestf "%s. Expected f to throw." message
 
 /// Expects the value to be a None value.
 let isNone x message =


### PR DESCRIPTION
In case when the function provided to `throwsT` threw no exception a misleading assert message was shown mentioning an `AssertException`.

The added test would fail with the following message:

> Should have failed with message containing: "Expected f to throw." but failed with "
> Should throw null arg. Expected f to throw an exn of type System.ArgumentNullException, but one of type Expecto.AssertException was thrown."
