### PR TITLE
add a C# friendly extension method for the nunit testresult xml

### DIFF
--- a/Expecto.TestResults/CSharp.fs
+++ b/Expecto.TestResults/CSharp.fs
@@ -1,0 +1,19 @@
+namespace Expecto.CSharp
+
+open System.Runtime.CompilerServices
+open Expecto
+
+
+// When exposing Extension Methods, you should declare an assembly-level attribute (in addition to class and method)
+[<assembly:Extension>]
+do
+  ()
+
+[<AutoOpen; Extension>]
+module ConfigExt =
+
+  type Expecto.Impl.ExpectoConfig with  
+
+      [<Extension; CompiledName("AddNUnitSummary")>]
+      member x.AddNUnitSummary(file:string, assemblyName:string) =
+          x.appendSummaryHandler (TestResults.writeNUnitSummary(file, assemblyName) )

--- a/Expecto.TestResults/Expecto.TestResults.fsproj
+++ b/Expecto.TestResults/Expecto.TestResults.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Library.fs" />
+    <Compile Include="CSharp.fs" />
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>

--- a/Expecto.Tests.CSharp/Expecto.Tests.CSharp.csproj
+++ b/Expecto.Tests.CSharp/Expecto.Tests.CSharp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Expecto.Tests.CSharp</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -12,6 +12,7 @@
     <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Expecto.TestResults\Expecto.TestResults.fsproj" />
     <ProjectReference Include="..\Expecto\Expecto.fsproj" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />

--- a/Expecto.Tests.CSharp/Tests.cs
+++ b/Expecto.Tests.CSharp/Tests.cs
@@ -83,6 +83,14 @@ namespace Test.CSharp
                 })
             });
 
-        public static int Main(string[] argv) => Runner.RunTestsInAssembly(Runner.DefaultConfig.WithMySpiritIsWeak(false).AddPrinter(new CSharpPrinter()), argv);
+        public static int Main(string[] argv)
+        {
+            var config =
+                Runner.DefaultConfig
+                    .WithMySpiritIsWeak(false)
+                    .AddPrinter(new CSharpPrinter())
+                    .AddNUnitSummary("test.xml", "someAssembly");
+            return Runner.RunTestsInAssembly(config, argv);
+        }
     }
 }


### PR DESCRIPTION
Before:

```c#
config.appendSummaryHandler(FSharpFunc<Impl.TestRunSummary, Unit>.FromConverter( s => { TestResults.writeNUnitSummary("tests.xml", "MyAssemblyName", s); return null; }));
```