### PR TITLE
junit report: add option to treat errors like failures 

### DIFF
--- a/Expecto.TestResults/CSharp.fs
+++ b/Expecto.TestResults/CSharp.fs
@@ -1,5 +1,6 @@
 namespace Expecto.CSharp
 
+open System.Runtime.InteropServices
 open System.Runtime.CompilerServices
 open Expecto
 
@@ -18,6 +19,8 @@ module ConfigExt =
       member x.AddNUnitSummary(file:string, assemblyName:string) =
           x.appendSummaryHandler (TestResults.writeNUnitSummary(file, assemblyName) )
 
+          
+      /// If using this with gitlab, set the third parameter 'handleErrorsLikeFailures' to true.
       [<Extension; CompiledName("AddJUnitSummary")>]
-      member x.AddJUnitSummary(file:string, assemblyName:string) =
-          x.appendSummaryHandler (TestResults.writeJUnitSummary(file, assemblyName) )
+      member x.AddJUnitSummary(file:string, assemblyName:string, [<Optional;DefaultParameterValue(false)>]handleErrorsLikeFailures) =
+          x.appendSummaryHandler (TestResults.writeJUnitSummary(file, assemblyName, handleErrorsLikeFailures) )

--- a/Expecto.Tests.CSharp/Tests.cs
+++ b/Expecto.Tests.CSharp/Tests.cs
@@ -90,7 +90,8 @@ namespace Test.CSharp
                 Runner.DefaultConfig
                     .WithMySpiritIsWeak(false)
                     .AddPrinter(new CSharpPrinter())
-                    .AddNUnitSummary("bin/Expecto.Tests.CSharp.TestResults.xml", "someAssembly");
+                    .AddNUnitSummary("bin/Expecto.Tests.CSharp.TestResults.xml", "someAssembly")
+                    .AddJUnitSummary("bin/Expecto.Tests.CSharp.TestResults.junit.xml", "someAssembly", handleErrorsLikeFailures: true);
             return Runner.RunTestsInAssembly(config, argv);
         }
     }


### PR DESCRIPTION
because gitlab can't yet handle errors.

![grafik](https://user-images.githubusercontent.com/4236651/46086217-ed50e100-c1a7-11e8-84b2-9ab0c3ed7c56.png)

![grafik](https://user-images.githubusercontent.com/4236651/46086261-035ea180-c1a8-11e8-93b5-dc2dc2572b4a.png)

--------------

see https://gitlab.com/gitlab-org/gitlab-ce/blob/master/lib/gitlab/ci/parsers/junit.rb#L45-52
and issue https://gitlab.com/gitlab-org/gitlab-ce/issues/51087

This also means that skipped tests aren't surfaced anywhere and are treated as successfull. Which isn't great, but I guess they didn't fail ...

-------

I know you _just_ pushed a release yesterday, but for when do you plan the next?

Asking whether I should wait for official, or just build a nupkg myself.

Thank you!