### PR TITLE
fix: Expect.equal error when actual is null.

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -57,6 +57,16 @@ let tests =
         Expect.equal (testName()) "all/testName tests/two test" "two name"
     ]
 
+    testList "null comparison" [
+      testCase "actual" (fun _ ->
+        Expect.equal null (obj()) ""
+      ) |> assertTestFails
+
+      testCase "expected" (fun _ ->
+        Expect.equal (obj()) null ""
+      ) |> assertTestFails
+    ]
+
     testList "string comparison" [
       test "string equal" {
         Expect.equal "Test string" "Test string" "Test string"

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -262,7 +262,7 @@ let equal (actual : 'a) (expected : 'a) message =
       Tests.failtestf "%s. Actual value was %f but had expected it to be %f." message a e
   | a, e ->
     if actual <> expected then
-      if FSharpType.IsRecord(a.GetType(), BindingFlags.Default) then
+      if a <> null && FSharpType.IsRecord(a.GetType(), BindingFlags.Default) then
         let value (elem: obj) previous =
           (elem :?> PropertyInfo).GetValue(previous, null)
         let ai = (FSharpType.GetRecordFields (a.GetType(), BindingFlags.Public)).GetEnumerator()


### PR DESCRIPTION
`FSharpType.IsRecord(a.GetType(), BindingFlags.Default) `  when `a = null` 

```fsharp
testProperty "json >> domain = id" <| fun value -> 
    value
    |> json
    |> domain<string A>
    |> Expect.equal "" value
```

```
[16:03:59 DBG] Backward Compatible SingleDu/json >> domain = id starting... <Expecto>
[16:03:59 ERR] Backward Compatible SingleDu/json >> domain = id failed in 00:00:00.4850000.
Failed after 10 tests. Parameters:
        A null
Result:
        Exception
  System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Object.GetType()
   at Expecto.Expect.equal$cont@264[a](a actual, a expected, String message, Object e, Object a, Unit unitVar) in C:\Users\Anthony Lloyd\src\expecto\Expecto\Expect.fs:line 265
   at Microsoft.FSharpLu.Json.Tests.BackwardCompatibleSingleDu.tests@94-8.Invoke(A`1 value) in D:\Users\Klei\Source\Repos\Rosdex-ML\tests\Rosdex.Services.Core.Tests\Microsoft.FSharpLu.Json.Tests.fs:line 98
   at FsCheck.Testable.evaluate[a,b](FSharpFunc`2 body, a a)
Focus on error:
        etestProperty (256433196, 296522512) "json >> domain = id" <Expecto>
[16:03:59 DBG] Backward Compatible SingleDu/AAA/json AAA value = json value starting... <Expecto>```