### PR TITLE
update logary sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ open Hopac
 open Logary
 open Logary.Configuration
 open Logary.Adapters.Facade
+open Logary.Targets
 
 [<EntryPoint>]
 let main argv =


### PR DESCRIPTION
The `Logary.Targets`  namespace seems required to get `LiterateConsole` in scope.