### PR TITLE
Introduce Expect.wantSome and Expect.wantOk.

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -54,9 +54,9 @@ let tests =
 
     testList "testName tests" [
       testCase "one test" <| fun _ ->
-        Expect.equal (testName()) "all/testName tests/one test" "one name"
+        Expect.equal testName "all/testName tests/one test" "one name"
       testCase "two test" <| fun _ ->
-        Expect.equal (testName()) "all/testName tests/two test" "two name"
+        Expect.equal testName "all/testName tests/two test" "two name"
     ]
 
     testList "null comparison" [

--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -90,8 +90,9 @@ let throwsC f cont =
   | Some e -> cont e
   | _ -> failtestf "Expected f to throw."
 
+[<RequiresExplicitTypeArguments>]
 /// Expects the passed function to throw `'texn`.
-let throwsT<'texn> f message =
+let throwsT<'texn when 'texn :> exn> f message =
   let thrown =
     try
       f ()
@@ -110,19 +111,20 @@ let throwsT<'texn> f message =
 /// Expects the value to be a None value.
 let isNone x message =
   match x with
-  | None ->
-    ()
+  | None -> ()
   | Some x ->
-    failtestf "%s. Expected None, was Some(%A)."
-      message x
+    failtestf "%s. Expected None, was Some(%A)." message x
 
-/// Expects the value to be a Some _ value.
-let isSome x message =
+/// Expects the value to be a Some x value
+/// and returns x or fails the test.
+let wantSome x message =
   match x with
   | None ->
     failtestf "%s. Expected Some _, was None." message
-  | Some _ ->
-    ()
+  | Some x -> x
+
+/// Expects the value to be a Some _ value.
+let isSome x message = wantSome x message |> ignore
 
 /// Expects the value to be a Choice1Of2 value.
 let isChoice1Of2 x message =
@@ -137,15 +139,18 @@ let isChoice2Of2 x message =
   | Choice1Of2 x ->
     failtestf "%s. Expected Choice2Of2 _, was Choice1Of2(%A)."
       message x
-  | Choice2Of2 _ ->
-    ()
+  | Choice2Of2 _ -> ()
 
-/// Expects the value to be a Result.Ok value.
-let isOk x message =
+/// Expects the value to be a Result.Ok value
+/// and returns it or fails the test.
+let wantOk x message =
   match x with
-  | Ok _ -> ()
+  | Ok x -> x
   | Result.Error x ->
     failtestf "%s. Expected Ok, was Error(%A)." message x
+
+/// Expects the value to be a Result.Ok value.
+let isOk x message = wantOk x message |> ignore
 
 /// Expects the value to be a Result.Error value.
 let isError x message =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -50,12 +50,14 @@ module Tests =
     ) format
 
   /// The full name of the currently running test
-  let testName() = TestNameHolder.Name
+  // The generic parameter allows it to be used like
+  // a value, instead of calling testName().
+  let testName<'unused> = TestNameHolder.Name
 
   /// Fail this test
   let inline failtest msg = raise <| AssertException msg
   /// Fail this test
-  let inline failtestf fmt = Printf.ksprintf (AssertException >> raise) fmt
+  let inline failtestf fmt = Printf.ksprintf failtest fmt
   /// Fail this test
   let inline failtestNoStack msg = raise <| FailedException msg
   /// Fail this test

--- a/Expecto/Flip.Expect.fs
+++ b/Expecto/Flip.Expect.fs
@@ -6,11 +6,16 @@ let inline throws message f = Expecto.Expect.throws f message
 /// Expects f to throw, and calls `cont` with its exception.
 let inline throwsC cont f = Expecto.Expect.throwsC f cont
 
+[<RequiresExplicitTypeArguments>]
 /// Expects the passed function to throw `'texn`.
-let inline throwsT<'texn> message f = Expecto.Expect.throwsT<'texn> f message
+let inline throwsT<'texn when 'texn :> exn> message f = Expecto.Expect.throwsT<'texn> f message
 
 /// Expects the value to be a None value.
 let inline isNone message x = Expecto.Expect.isNone x message
+
+/// Expects the value to be a Some x value
+/// and returns x or fails the test.
+let wantSome message x = Expecto.Expect.wantSome x message
 
 /// Expects the value to be a Some _ value.
 let inline isSome message x = Expecto.Expect.isSome x message
@@ -20,6 +25,10 @@ let inline isChoice1Of2 message x = Expecto.Expect.isChoice1Of2 x message
 
 /// Expects the value to be a Choice2Of2 value.
 let inline isChoice2Of2 message x = Expecto.Expect.isChoice2Of2 x message
+
+/// Expects the value to be a Result.Ok value
+/// and returns it or fails the test.
+let inline wantOk message x = Expecto.Expect.wantOk x message
 
 /// Expects the value to be a Result.Ok value.
 let inline isOk message x = Expecto.Expect.isOk x message


### PR DESCRIPTION
They act like `isSome`/`isOk`, but also return the expected value.
Also, `testName` is now a genericvalue (to make it feel more like a value), and `throwsT` requires an explicit type argument.
The former is a breaking change (that is justified by the major version bump), and the latter is technically a breaking change as well, but more of an enforcement of how the function should have been used.