### PR TITLE
#378 pass filtered tests instead of not filtered.

### DIFF
--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -518,7 +518,7 @@ module Impl =
       noSpinner: bool
       /// Set the level of colours to use.
       colour: ColourLevel
-      /// Split test names by `.` instead of `/`
+      /// Split test names by `.` or `/`
       joinWith: JoinWith
     }
     static member defaultConfig =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -336,7 +336,7 @@ module Tests =
     | Debug
     /// Set the process name to log under (default: "Expecto").
     | Log_Name of name:string
-    /// Filters the list of tests by a hierarchy that's slash (/) separated.
+    /// Filters the list of tests by a hierarchy that's separated by a `joinWith` operator.
     | Filter of hiera:string
     /// Filters the list of test lists by a given substring.
     | Filter_Test_List of substring:string
@@ -520,8 +520,8 @@ module Tests =
       if config.allowDuplicateNames || List.isEmpty duplicates.Value then
         let retCode =
           match config.stress with
-          | None -> runEvalWithCancel ct config tests |> Async.RunSynchronously
-          | Some _ -> runStressWithCancel ct config tests |> Async.RunSynchronously
+          | None -> runEvalWithCancel ct config fTests |> Async.RunSynchronously
+          | Some _ -> runStressWithCancel ct config fTests |> Async.RunSynchronously
         afterRunTestsInvoke()
         retCode
       else


### PR DESCRIPTION
Fixes: #378

The wrong parameter was passed in Expecto.fs lines 523/524. The changes were introduce in this [commit](https://github.com/haf/expecto/commit/b168ca3e186b7c7bf5e4ac36fc99ec558aee2126) because of a rename from `tests` to `fTests` :(. 
 
CC: @haf 