### PR TITLE
#360 - usage of deprecated functions in README.md

### DIFF
--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -510,7 +510,7 @@ module Impl =
       /// FsCheck end size (default: 100 for testing and 10,000 for
       /// stress testing).
       fsCheckEndSize: int option
-      /// Depricated. Will be removed on next major release.
+      /// Deprecated. Will be removed on next major release.
       mySpiritIsWeak: bool
       /// Allows duplicate test names.
       allowDuplicateNames: bool

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -370,6 +370,7 @@ module Tests =
     | Verbosity of LogLevel
     /// Append a summary handler.
     | Append_Summary_Handler of SummaryHandler
+    /// Specify test names join character.
     | JoinWith of split: string
 
   let options = [

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -503,6 +503,7 @@ module Tests =
     )
   /// Runs tests with the supplied config.
   /// Returns 0 if all tests passed, otherwise 1
+  /// Deprecated: please use runTestsWithCLIArgsAndCancel.
   let runTestsWithCancel (ct:CancellationToken) config (tests:Test) =
     ANSIOutputWriter.setColourLevel config.colour
     Global.initialiseIfDefault
@@ -533,6 +534,7 @@ module Tests =
         1
   /// Runs tests with the supplied config.
   /// Returns 0 if all tests passed, otherwise 1
+  /// Deprecated: please use runTestsWithCLIArgs.
   let runTests config tests =
     runTestsWithCancel CancellationToken.None config tests
 
@@ -565,6 +567,7 @@ module Tests =
 
   /// Runs all given tests with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
+  /// Deprecated: please use runTestsWithCLIArgs.
   let runTestsWithArgs config args tests =
     runTestsWithArgsAndCancel CancellationToken.None config args tests
 
@@ -575,6 +578,7 @@ module Tests =
 
   /// Runs tests in this assembly with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
+  /// Deprecated: please use runTestsInAssemblyWithCLIArgsAndCancel
   let runTestsInAssemblyWithCancel (ct:CancellationToken) config args =
     let config = { config with locate = getLocation (Assembly.GetEntryAssembly()) }
     testFromThisAssembly ()
@@ -592,6 +596,7 @@ module Tests =
 
   /// Runs tests in this assembly with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
+  /// Deprecated: please use runTestsInAssemblyWithCLIArgs
   let runTestsInAssembly config args =
     runTestsInAssemblyWithCancel CancellationToken.None config args
 

--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ testCase "A simple test" (fun () ->
 ### `runTests`
 
 Signature `ExpectoConfig -> Test -> int`. Runs the passed tests with the passed
-configuration record. Note: now depricated please use CLIArgs below.
+configuration record. Note: now deprecated please use CLIArgs below.
 
 ### `runTestsWithArgs`
 
 Signature `ExpectoConfig -> string[] -> Test -> int`. Runs the passed tests
 and also overrides the passed `ExpectoConfig` with the command line parameters.
-Note: now depricated please use CLIArgs below.
+Note: now deprecated please use CLIArgs below.
 
 ### `runTestsWithCLIArgs`
 
@@ -247,13 +247,13 @@ and also overrides the passed `CLIArguments` with the command line parameters.
 ### `runTestsWithCancel`
 
 Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests with the passed
-configuration record. Note: now depricated please use CLIArgs below.
+configuration record. Note: now deprecated please use CLIArgs below.
 
 ### `runTestsWithArgsAndCancel`
 
 Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests
 and also overrides the passed `ExpectoConfig` with the command line parameters.
-configuration record. Note: now depricated please use CLIArgs below.
+configuration record. Note: now deprecated please use CLIArgs below.
 
 ### `runTestsWithCLIArgsAndCancel`
 
@@ -265,7 +265,7 @@ and also overrides the passed `CLIArguments` with the command line parameters.
 Signature `ExpectoConfig -> string[] -> int`. Runs the tests in the current
 assembly and also overrides the passed `ExpectoConfig` with the command line
 parameters. All tests need to be marked with the `[<Tests>]` attribute.
-Note: now depricated please use CLIArgs below.
+Note: now deprecated please use CLIArgs below.
 
 ### `runTestsInAssemblyWithCLIArgs`
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,13 @@ What follows is the Table of Contents for this README, which also serves as the 
   - [`runTests`](#runtests)
   - [`runTestsWithArgs`](#runtestswithargs)
   - [`runTestsWithCLIArgs`](#runtestswithcliargs)
+  - [`runTestsWithCancel`](#runTestsWithCancel)
+  - [`runTestsWithArgsAndCancel`](#runTestsWithArgsAndCancel)
+  - [`runTestsWithCLIArgsAndCancel`](#runTestsWithCLIArgsAndCancel)
   - [`runTestsInAssembly`](#runtestsinassembly)
   - [`runTestsInAssemblyWithCLIArgs`](#runtestsinassemblywithcliargs)
+  - [`runTestsInAssemblyWithCancel`](#runTestsInAssemblyWithCancel)
+  - [`runTestsInAssemblyWithCLIArgsAndCancel`](#runTestsInAssemblyWithCLIArgsAndCancel)
   - [Filtering with `filter`](#filtering-with-filter)
   - [Shuffling with `shuffle`](#shuffling-with-shuffle)
   - [Stress testing](#stress-testing)
@@ -124,7 +129,7 @@ let main argv =
   LogaryFacadeAdapter.initialise<Expecto.Logging.Logger> logary
 
   // Invoke Expecto:
-  runTestsInAssembly defaultConfig argv
+  runTestsInAssemblyWithCLIArgs [] argv
 ```
 
 Now, when you use Logary in your app, you can see your log messages
@@ -182,7 +187,7 @@ let tests =
 
 [<EntryPoint>]
 let main args =
-  runTestsWithArgs defaultConfig args tests
+  runTestsWithCLIArgs [] args tests
 ```
 
 No magic is involved here. We just created a single test and hooked it
@@ -209,7 +214,7 @@ let simpleTest =
 Then run it like this, e.g. in the interactive or through a console app.
 
 ```fsharp
-runTests defaultConfig simpleTest
+runTestsWithCLIArgs [] [||] simpleTest
 ```
 
 which returns 1 if any tests failed, otherwise 0. Useful for returning to the
@@ -239,6 +244,22 @@ Note: now depricated please use CLIArgs below.
 Signature `CLIArguments seq -> string[] -> Test -> int`. Runs the passed tests
 and also overrides the passed `CLIArguments` with the command line parameters.
 
+### `runTestsWithCancel`
+
+Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests with the passed
+configuration record. Note: now depricated please use CLIArgs below.
+
+### `runTestsWithArgsAndCancel`
+
+Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests
+and also overrides the passed `ExpectoConfig` with the command line parameters.
+configuration record. Note: now depricated please use CLIArgs below.
+
+### `runTestsWithCLIArgsAndCancel`
+
+Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests
+and also overrides the passed `CLIArguments` with the command line parameters.
+
 ### `runTestsInAssembly`
 
 Signature `ExpectoConfig -> string[] -> int`. Runs the tests in the current
@@ -249,6 +270,18 @@ Note: now depricated please use CLIArgs below.
 ### `runTestsInAssemblyWithCLIArgs`
 
 Signature `CLIArguments seq -> string[] -> int`. Runs the tests in the current
+assembly and also overrides the passed `CLIArguments` with the command line
+parameters. All tests need to be marked with the `[<Tests>]` attribute.
+
+### `runTestsInAssemblyWithCancel`
+
+Signature `CancellationToken -> ExpectoConfig -> string[] -> int`. Runs the tests in the current
+assembly and also overrides the passed `ExpectoConfig` with the command line
+parameters. All tests need to be marked with the `[<Tests>]` attribute.
+
+### `runTestsInAssemblyWithCLIArgsAndCancel`
+
+Signature `CancellationToken -> CLIArguments seq -> string[] -> int`. Runs the tests in the current
 assembly and also overrides the passed `CLIArguments` with the command line
 parameters. All tests need to be marked with the `[<Tests>]` attribute.
 
@@ -621,7 +654,7 @@ let properties =
         a * (b + c) = a * b + a * c
   ]
 
-Tests.runTests defaultConfig properties
+Tests.runTestsWithCLIArgs [] [||] properties
 ```
 
 You can freely mix testProperty with testCase and testList. The config looks
@@ -697,7 +730,7 @@ let properties =
         Expect.isNotNull x.FirstName "First Name should not be null"
   ]
 
-Tests.runTests defaultConfig properties
+Tests.runTestsWithCLIArgs [] [||] properties
 ```
 
 And a further example of creating constraints on generated values
@@ -914,7 +947,7 @@ test "yup yup" {
   compute 2
     |> Expect.equal "x2 = 82" 84
 }
-|> runTests defaultConfig
+|> runTestsWithCLIArgs [] [||]
 ```
 
 ### `Performance` module
@@ -1078,7 +1111,7 @@ let findFastest =
 From code you can run:
 
 ```fsharp
-Tests.runTestsInAssembly [Stress 0.1;Stress_Timeout 0.2] [||]
+Tests.runTestsInAssemblyWithCLIArgs [Stress 0.1;Stress_Timeout 0.2] [||]
 ```
 
 From the command line you can run:
@@ -1222,7 +1255,7 @@ let main argv =
   LogaryFacadeAdapter.initialise<Expecto.Logging.Logger> logary
 
   // run all tests
-  Tests.runTestsInAssembly defaultConfig args
+  Tests.runTestsInAssemblyWithCLIArgs [] argv
 ```
 
 ## About test parallelism


### PR DESCRIPTION

- All usages of `deprecated` `runTestsXXX` removed from README.md (except line 153),
- All occurrences of `depricated` renamed to `deprecated`,
- Added comments with `deprecation` info to the following:
     - `runTestsWithCancel`
     - `runTests`
     - `runTestsWithArgsAndCancel`
     - `runTestsWithArgs`
     - `runTestsInAssemblyWithCancel`
     - `runTestsInAssembly`

@haf 