### PR TITLE
add options to list focused tests

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -275,7 +275,7 @@
 
   <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
-      <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+      <!-- <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec> -->
     </PropertyGroup>
   </Target>
 

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -275,7 +275,7 @@
 
   <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
-      <!-- <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec> -->
+      <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
     </PropertyGroup>
   </Target>
 

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -489,6 +489,7 @@ let expecto =
             "--filter-test-case"; "f case"
             "--run"; "a"; "b"; "c"
             "--list-tests"
+            "--list-tests"; "normal"; "FOCUSED"; "Pending"
             "--summary"
             "--version"
             "--summary-location"
@@ -515,7 +516,8 @@ let expecto =
           Filter_Test_List "f list"
           Filter_Test_Case "f case"
           Run ["a";"b";"c"]
-          List_Tests
+          List_Tests []
+          List_Tests [Normal; Focused; Pending]
           Summary
           Version
           Summary_Location

--- a/Expecto/CSharp.fs
+++ b/Expecto/CSharp.fs
@@ -52,6 +52,8 @@ module Runner =
   let RunTestsInAssembly(config, args) = runTestsInAssembly config args
   let RunTestsInAssemblyWithCLIArgs(cliArgs, args) = runTestsInAssemblyWithCLIArgs cliArgs args
   let ListTests(tests) = listTests tests
+  let ListFocusedTests(tests) = listFocusedTests tests
+  let ListPendingTests(tests) = listPendingTests tests
   let TestList(name, tests: IEnumerable<Test>) = testList name (List.ofSeq tests)
   [<CompiledName("TestCase")>]
   let TestCaseA(name, test: System.Action) = testCase name test.Invoke

--- a/Expecto/CSharp.fs
+++ b/Expecto/CSharp.fs
@@ -51,9 +51,7 @@ module Runner =
   let RunTestsWithCLIArgs(cliArgs, args, tests) = runTestsWithCLIArgs cliArgs args tests
   let RunTestsInAssembly(config, args) = runTestsInAssembly config args
   let RunTestsInAssemblyWithCLIArgs(cliArgs, args) = runTestsInAssemblyWithCLIArgs cliArgs args
-  let ListTests(tests) = listTests tests
-  let ListFocusedTests(tests) = listFocusedTests tests
-  let ListPendingTests(tests) = listPendingTests tests
+  let ListTests(config, tests) = listTests config tests
   let TestList(name, tests: IEnumerable<Test>) = testList name (List.ofSeq tests)
   [<CompiledName("TestCase")>]
   let TestCaseA(name, test: System.Action) = testCase name test.Invoke

--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -494,6 +494,8 @@ module Impl =
       /// An optional filter function. Useful if you only would
       /// like to run a subset of all the tests defined in your assembly.
       filter   : Test -> Test
+      /// List tests of specified state
+      listStates : FocusState list
       /// Allows the test printer to be parametised to your liking.
       printer : TestPrinters
       /// Verbosity level (default: Info).
@@ -528,6 +530,7 @@ module Impl =
         stressTimeout = TimeSpan.FromMinutes 5.0
         stressMemoryLimit = 100.0
         filter = id
+        listStates = []
         failOnFocusedTests = false
         printer =
           let tc = Environment.GetEnvironmentVariable "TEAMCITY_PROJECT_NAME"

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -505,16 +505,18 @@ module Tests =
     tests
     |> Seq.iter (fun (stateChar, name) ->
       if hideState then
-        Printf.bprintf result "%s\n" name
-        //logger.info (Message.eventX "{name}" >> Message.setField "name" name)
+        Printf.bprintf result "\n%s" name
       else
-        // logger.info (Message.eventX "{stateChar} {name}"
-        //   >> Message.setField "stateChar" stateChar
-        //   >> Message.setField "name" name
-        // )
-        Printf.bprintf result "%s %s\n" stateChar name
+        Printf.bprintf result "\n%s %s" stateChar name
     )
-    logger.info (Message.eventX "{result}" >> Message.setField "result" (string result))
+    Printf.bprintf result "\n"
+
+    logger.logWithAck Info (
+      Message.eventX "{result}"
+      >> Message.setField "result" (string result)
+    )
+    |> Async.RunSynchronously
+    Printf.printfn "" // TODO workaround to flush output
 
   /// Prints out names of all tests for given test suite.
   let duplicatedNames (join: JoinWith) test =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -501,12 +501,20 @@ module Tests =
 
     let hideState = tests |> List.exists(fun (stateChar,_) -> stateChar <> "N") |> not
 
+    let result = System.Text.StringBuilder()
     tests
     |> Seq.iter (fun (stateChar, name) ->
       if hideState then
-        printfn "%s" name
+        Printf.bprintf result "%s\n" name
+        //logger.info (Message.eventX "{name}" >> Message.setField "name" name)
       else
-        printfn "%s %s" stateChar name)
+        // logger.info (Message.eventX "{stateChar} {name}"
+        //   >> Message.setField "stateChar" stateChar
+        //   >> Message.setField "name" name
+        // )
+        Printf.bprintf result "%s %s\n" stateChar name
+    )
+    logger.info (Message.eventX "{result}" >> Message.setField "result" (string result))
 
   /// Prints out names of all tests for given test suite.
   let duplicatedNames (join: JoinWith) test =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -486,10 +486,10 @@ module Tests =
 
   /// Prints out names of all tests for given test suite.
   let listTests config test =
-      Test.toTestCodeList test
-      |> Seq.filter(fun t -> List.isEmpty config.listStates ||
-                             List.contains t.state config.listStates)
-      |> Seq.iter (fun t -> printfn "%s" (config.joinWith.format t.name))
+    Test.toTestCodeList test
+    |> Seq.filter(fun t -> List.isEmpty config.listStates ||
+                           List.contains t.state config.listStates)
+    |> Seq.iter (fun t -> printfn "%s" (config.joinWith.format t.name))
 
   /// Prints out names of all tests for given test suite.
   let duplicatedNames (join: JoinWith) test =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -486,10 +486,27 @@ module Tests =
 
   /// Prints out names of all tests for given test suite.
   let listTests config test =
-    Test.toTestCodeList test
-    |> Seq.filter(fun t -> List.isEmpty config.listStates ||
-                           List.contains t.state config.listStates)
-    |> Seq.iter (fun t -> printfn "%s" (config.joinWith.format t.name))
+    let toStateChar state =
+      match state with
+      | Normal  -> "N"
+      | Pending -> "P"
+      | Focused -> "F"
+
+    let tests =
+      Test.toTestCodeList test
+      |> Seq.filter(fun t -> List.isEmpty config.listStates ||
+                             List.contains t.state config.listStates)
+      |> Seq.map(fun t -> toStateChar t.state, config.joinWith.format t.name)
+      |> Seq.toList
+
+    let hideState = tests |> List.exists(fun (stateChar,_) -> stateChar <> "N") |> not
+
+    tests
+    |> Seq.iter (fun (stateChar, name) ->
+      if hideState then
+        printfn "%s" name
+      else
+        printfn "%s %s" stateChar name)
 
   /// Prints out names of all tests for given test suite.
   let duplicatedNames (join: JoinWith) test =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -516,7 +516,6 @@ module Tests =
       >> Message.setField "result" (string result)
     )
     |> Async.RunSynchronously
-    Printf.printfn "" // TODO workaround to flush output
 
   /// Prints out names of all tests for given test suite.
   let duplicatedNames (join: JoinWith) test =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -299,6 +299,7 @@ module Tests =
 
     let inline parse case: Parser<'a> = parseWith tryParse case
     let inline number case: Parser<'a> = parseWith tryParseNumber case
+    let inline focusState case: Parser<'a> = parseWith tryParseFocusState case
 
 
   [<ReferenceEquality>]
@@ -341,11 +342,7 @@ module Tests =
     /// Runs only provided list of tests.
     | Run of tests:string list
     /// Don't run tests, but prints out list of tests instead.
-    | List_Tests
-    /// Don't run tests, but prints out list of focused tests instead.
-    | List_Focused_Tests
-    /// Don't run tests, but prints out list of pending tests instead.
-    | List_Pending_Tests
+    | List_Tests of listStates: FocusState list
     /// Print out a summary after all tests are finished.
     | Summary
     /// Put an NUnit-like summary XML file at the given file.
@@ -387,9 +384,7 @@ module Tests =
       "--filter-test-list", "Filters the list of test lists by a given substring.", Args.string Filter_Test_List
       "--filter-test-case", "Filters the list of test cases by a given substring.", Args.string Filter_Test_Case
       "--run", "Runs only provided list of tests.", Args.list Args.string Run
-      "--list-tests", "Don't run tests, but prints out list of tests instead.", Args.none List_Tests
-      "--list-focused-tests", "Don't run tests, but prints out list of focused tests instead.", Args.none List_Focused_Tests
-      "--list-pending-tests", "Don't run tests, but prints out list of pending tests instead.", Args.none List_Pending_Tests
+      "--list-tests", "Don't run tests, but prints out list of tests instead. Lists only tests with specified state(s), or all tests if not.", Args.list (Args.focusState) List_Tests
       "--summary", "Print out a summary after all tests are finished.", Args.none Summary
       "--nunit-summary", "Put an NUnit-like summary XML file at the given file.", Args.string NUnit_Summary
       "--junit-summary", "Put a JUnit-like summary XML file at the given file.", Args.string JUnit_Summary
@@ -408,8 +403,6 @@ module Tests =
   type FillFromArgsResult =
     | ArgsRun of ExpectoConfig
     | ArgsList of ExpectoConfig
-    | ArgsListFocused of ExpectoConfig
-    | ArgsListPending of ExpectoConfig
     | ArgsVersion of ExpectoConfig
     | ArgsUsage of usage:string * errors:string list
 
@@ -439,9 +432,7 @@ module Tests =
     | Filter_Test_List name ->  fun o -> {o with filter = Test.filter o.joinWith.asString (fun s -> s |> getTestList |> List.exists(fun s -> s.Contains name )) }
     | Filter_Test_Case name ->  fun o -> { o with filter = Test.filter o.joinWith.asString (fun s -> s |> getTestCase |> fun s -> s.Contains name )}
     | Run tests -> fun o -> {o with filter = Test.filter o.joinWith.asString (fun s -> tests |> List.exists ((=) (o.joinWith.format s)) )}
-    | List_Tests -> id
-    | List_Focused_Tests -> id
-    | List_Pending_Tests -> id
+    | List_Tests states -> fun o -> { o with listStates = states }
     | Summary -> fun o -> {o with printer = TestPrinters.summaryPrinter o.printer}
     | NUnit_Summary path -> fun o -> o.AddNUnitSummary(path)
     | JUnit_Summary path -> fun o -> o.AddJUnitSummary(path)
@@ -480,12 +471,8 @@ module Tests =
       | Ok cliArguments ->
           let config =
             Seq.fold (fun s a -> foldCLIArgumentToConfig a s) baseConfig cliArguments
-          if List.contains List_Tests cliArguments then
+          if List.exists(function List_Tests _ -> true | _ -> false) cliArguments then
             ArgsList config
-          elif List.contains List_Focused_Tests cliArguments then
-            ArgsListFocused config
-          elif List.contains List_Pending_Tests cliArguments then
-            ArgsListPending config
           elif List.contains Version cliArguments then
             ArgsVersion config
           else
@@ -498,21 +485,11 @@ module Tests =
         ArgsUsage (Args.usage commandName options, errors)
 
   /// Prints out names of all tests for given test suite.
-  let listTests (join: JoinWith) test =
-    Test.toTestCodeList test
-    |> Seq.iter (fun t -> printfn "%s" (join.format t.name))
-
-  /// Prints out names of all focused tests for given test suite.
-  let listFocusedTests (join: JoinWith) test =
-    Test.toTestCodeList test
-    |> Seq.filter(fun t -> t.state = Focused)
-    |> Seq.iter (fun t -> printfn "%s" (join.format t.name))
-
-  /// Prints out names of all focused tests for given test suite.
-  let listPendingTests (join: JoinWith) test =
-    Test.toTestCodeList test
-    |> Seq.filter(fun t -> t.state = Pending)
-    |> Seq.iter (fun t -> printfn "%s" (join.format t.name))
+  let listTests config test =
+      Test.toTestCodeList test
+      |> Seq.filter(fun t -> List.isEmpty config.listStates ||
+                             List.contains t.state config.listStates)
+      |> Seq.iter (fun t -> printfn "%s" (config.joinWith.format t.name))
 
   /// Prints out names of all tests for given test suite.
   let duplicatedNames (join: JoinWith) test =
@@ -570,16 +547,7 @@ module Tests =
       printfn "EXPECTO! v%s\n\n%s" expectoVersion usage
       if List.isEmpty errors then 0 else 1
     | ArgsList config ->
-      config.filter tests
-      |> listTests config.joinWith
-      0
-    | ArgsListFocused config ->
-      config.filter tests
-      |> listFocusedTests config.joinWith
-      0
-    | ArgsListPending config ->
-      config.filter tests
-      |> listPendingTests config.joinWith
+      listTests config tests
       0
     | ArgsRun config ->
       runTestsWithCancel ct config tests

--- a/Expecto/Helpers.fs
+++ b/Expecto/Helpers.fs
@@ -72,6 +72,14 @@ let matchFocusAttributes = function
   | "Expecto.PTestsAttribute" -> Some (3, Pending)
   | _ -> None
 
+let inline tryParseFocusState (input: string) =
+  let inline (=~) (input : string) (value: string) =
+    input.Equals(value, StringComparison.OrdinalIgnoreCase)
+  if   input =~ "focused" then Some Focused
+  elif input =~ "pending" then Some Pending
+  elif input =~ "normal" then Some Normal
+  else None
+
 let allTestAttributes =
   Set [
     typeof<FTestsAttribute>.FullName

--- a/Expecto/Logging.fs
+++ b/Expecto/Logging.fs
@@ -1177,6 +1177,7 @@ type LiterateConsoleTarget(name, minLevel, ?options, ?literateTokeniser, ?output
   let colourWriter = outputWriter |> Option.defaultWith (fun () ->
     ANSIOutputWriter.prettyPrint (minLevel <= Debug) sem
   )
+  let flush() = ANSIOutputWriter.flush()
 
   /// Converts the message to tokens, apply the theme, then output them using the `colourWriter`.
   let writeColourisedThenNewLine message =
@@ -1202,7 +1203,10 @@ type LiterateConsoleTarget(name, minLevel, ?options, ?literateTokeniser, ?output
     member __.name = name
     member __.logWithAck level msgFactory =
       if level >= minLevel then
-        async { do writeColourisedThenNewLine (msgFactory level) }
+        async {
+          writeColourisedThenNewLine (msgFactory level)
+          flush()
+          }
       else
         async.Return ()
     member __.log level msgFactory =

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 9.0.3 - 2020-07-27
+* List focused tests if failed using `--fail-on-focused-tests`, #392, thanks @vilinski
+* Add an option to specify test states in `--list-tests`, thanks @vilinski
+
 #### 9.0.2 - 2020-06-25
 * An eta-expansion caused ABI compatibility for dependents, #388, thanks @haf
 
@@ -8,7 +12,7 @@
 * Add `Expect.wantError`, which returns the value inside the Result wrapper if successful, thanks @yreynhout
 
 #### 9.0.0 - 2020-04-04
-* Change the default test separator to `.` (dot). Override back, using `--join-with /` Big thanks @MNie 
+* Change the default test separator to `.` (dot). Override back, using `--join-with /` Big thanks @MNie
 * Add `Expect.wantSome` and `Expect.wantOk`, which returns the value inside the Option/Result wrapper if successful, thanks @teo-tsirpanis
 * Remove deprecated PackageIconUrl from the build props, replace with PackageIcon, thanks @teo-tsirpanis
 * Add cmd file for building on Windows, thanks @teo-tsirpanis


### PR DESCRIPTION
following PR to enhancement #392  

Proposed changes and usage:
- `--list-tests` - lists all tests as before
- `--list-tests focused` - lists focused tests only
- `--list-tests pending focused` - lists pending and focused tests only
- added a "state char" before test name (N, P, F). It is hidden as before, if none of listed tests are focused or pending (not the case in Expecto.Tests)

```
P pending_test.case.one 
F focused_test.case.two
N normal_test.case.three 
```

