### PR TITLE
Fix flipped/mixed up Expecto.Diff formatting

### DIFF
--- a/Expecto.Diff/Library.fs
+++ b/Expecto.Diff/Library.fs
@@ -21,7 +21,7 @@ let colourisedDiff actual expected =
     | ChangeType.Deleted -> ColourText.colouriseText ConsoleColor.Red text
     | ChangeType.Modified -> ColourText.colouriseText ConsoleColor.Blue text
     | ChangeType.Imaginary -> ColourText.colouriseText ConsoleColor.Yellow text
-    | ChangeType.Unchanged | ChangeType.Imaginary | _ -> text
+    | ChangeType.Unchanged | _ -> text
 
   let colouriseLine (line: DiffPiece) =
     if line.SubPieces.Count = 0 then
@@ -33,11 +33,12 @@ let colourisedDiff actual expected =
   let colourisedDiff (lines: DiffPiece seq) =
     String.Join("\n", lines |> Seq.map colouriseLine)
 
-  let diff = sideBySideDiffer.BuildDiffModel(actual, expected)
+  let diff = sideBySideDiffer.BuildDiffModel(expected, actual)
   sprintf
-    "\n---------- Actual: --------------------\n%s\n---------- Expected: ------------------\n%s\n"
-    (colourisedDiff diff.OldText.Lines)
+    "\n%s---------- Expected: ------------------\n%s\n---------- Actual: --------------------\n%s\n"
+    (ColourText.colouriseText ConsoleColor.White "") // Reset colour.
     (colourisedDiff diff.NewText.Lines)
+    (colourisedDiff diff.OldText.Lines)
 
 let equals actual expected message =
   Expect.equalWithDiffPrinter colourisedDiff actual expected message


### PR DESCRIPTION
Fixes https://github.com/haf/expecto/issues/419

I tested this by running `dotnet run --project Expecto.Sample --framework net5.0` in this repo.

First, the default output for comparison:

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/2142817/116464000-b4031500-a86b-11eb-9077-0767c6c4ab99.png">

Notes:

- Expected comes first, then actual.
- Expected is in green, actual in red.

Then, the `Expecto.Diff` output:

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/2142817/116464135-e6ad0d80-a86b-11eb-99ad-c7b3b31e0459.png">

Notes:

- The Actual/Expected _headings_ are flipped compared to the default formatting.
- The actual/expected _text_ are still in the same order as the default formatting. In other words, the headings are for the wrong text.
- The colors are flipped compared to the default formatting.
- Also note how the first heading and `{A =` is blue, while it should be white.

Finally, the output with this PR:

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/2142817/116464384-355aa780-a86c-11eb-8657-6b75f1226624.png">

Notes:

- Fixed the headings so Expected comes first, just like in the default formatting. And now the headings and the actual/expected text match.
- Fixed the colors. Expected is now green and actual is red, just like the default formatting.
- Fixed the heading and start-of-text color. It’s now reset.