### PR TITLE
fix Testing "Hello world" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ What follows is the Table of Contents for this README, which also serves as the 
   - [Prettify stacktraces/ship test logs](#prettify-stacktracesship-test-logs)
   - [TestResults file](#testresults-file)
 - [.Net Core support](#net-core-support)
-- [Testing "Hello world"](#testing-%22hello-world%22)
+- [Testing "Hello world"](#testing-hello-world)
 - [Running tests](#running-tests)
   - [`runTests`](#runtests)
   - [`runTestsWithArgs`](#runtestswithargs)


### PR DESCRIPTION
While browsing the documentation I noticed that the "Testing Hello world" link in the Readme doesn't work correctly. This small PR fixes this.

I also verified [doctoc](https://github.com/thlorenz/doctoc) has a problem with quotes but it generates the TOC correctly so I'm not sure what went wrong [there](https://github.com/haf/expecto/commit/58436fdc7f0f10447efabb56a614ff64c60378f2).