### PR TITLE
Feature - Run tests from many assemblies

### DIFF
--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -1026,16 +1026,31 @@ module Impl =
       SourceLocation.empty
 
   /// Scan filtered tests marked with TestsAttribute from an assembly
-  let testFromAssemblyWithFilter typeFilter (a: Assembly) =
+  let testListFromAssemblyWithFilter typeFilter (a : Assembly) =
     a.GetExportedTypes()
     |> Seq.filter typeFilter
     |> Seq.choose testFromType
     |> Seq.toList
+
+  /// Scan filtered tests marked with TestsAttribute from an assembly
+  let testFromAssemblyWithFilter typeFilter (assembly : Assembly) =
+    testListFromAssemblyWithFilter typeFilter assembly
+    |> listToTestListOption
+
+  /// Scan filtered tests marked with TestsAttribute from multiple assemblies
+  let testFromAssembliesWithFilter typeFilter (assemblies : Assembly seq) =
+    assemblies
+    |> Seq.map (testListFromAssemblyWithFilter typeFilter)
+    |> List.concat
     |> listToTestListOption
 
   /// Scan tests marked with TestsAttribute from an assembly
   let testFromAssembly = testFromAssemblyWithFilter (fun _ -> true)
   // TODO v10 eta expansion: let testFromAssembly asm = testFromAssemblyWithFilter (fun _ -> true) asm
+
+  /// Scan tests marked with TestsAttribute from multiple assemblies
+  let testFromAssemblies assemblies = testFromAssembliesWithFilter (fun _ -> true) assemblies
+  // TODO v10 eta expansion: let testFromAssemblies assemblies asm = testFromAssembliesWithFilter (fun _ -> true) assemblies asm
 
   /// Scan tests marked with TestsAttribute from entry assembly
   let testFromThisAssembly () = testFromAssembly (Assembly.GetEntryAssembly())

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -618,6 +618,15 @@ module Tests =
     let tests = testFromThisAssembly() |> Option.orDefault (TestList ([], Normal))
     runTestsWithArgsAndCancel ct config args tests
 
+  /// Runs tests in the specified assemblies with the supplied command-line options.
+  /// Returns 0 if all tests passed, otherwise 1
+  let runTestsInAssembliesWithCLIArgsAndCancel (ct:CancellationToken) cliArgs args assemblies =
+    let config = { ExpectoConfig.defaultConfig
+                    with locate = getLocation (Assembly.GetEntryAssembly()) }
+    let config = Seq.fold (fun s a -> foldCLIArgumentToConfig a s) config cliArgs
+    let tests = testFromAssemblies assemblies |> Option.orDefault (TestList ([], Normal))
+    runTestsWithArgsAndCancel ct config args tests
+
   /// Runs tests in this assembly with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
   /// Deprecated: please use runTestsInAssemblyWithCLIArgs

--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ Signature `CancellationToken -> CLIArguments seq -> string[] -> int`. Runs the t
 assembly and also overrides the passed `CLIArguments` with the command line
 parameters. All tests need to be marked with the `[<Tests>]` attribute.
 
+### `runTestsInAssembliesWithCLIArgsAndCancel`
+
+Signature `CancellationToken -> CLIArguments seq -> string[] -> seq<Assembly> -> int`. Runs the
+tests in all the specified assemblies and also overrides the passed `CLIArguments` with the
+command line parameters. All tests need to be marked with the `[<Tests>]` attribute.
+
 ### Filtering with `filter`
 
 You can single out tests by filtering them by name (e.g. in the


### PR DESCRIPTION
When there are multiple assemblies of tests for an FSharp project, it is a pain to run each project of tests individually using the `dotnet` cli.
I think it's valuable to use the `dotnet watch` tooling as well which doesn't work as nicely with multiple test projects either.
This PR adds the ability to specify multiple assemblies from the test runner in the `Main.fs` file when calling `runTestsInAssembly`.
That way all the results show up in one big list and we can use useful tooling like `dotnet watch` on a single project.
