### PR TITLE
Update F# Version to most current (6)

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,7 +3,7 @@ framework net461, netstandard2.0, netcoreapp3.1, net5.0
 storage none
 version 5.245.1
 
-nuget FSharp.Core 4.6.0
+nuget FSharp.Core ~6
 nuget FsCheck ~> 2.14
 nuget Hopac ~> 0.4
 nuget DiffPlex ~> 1.5


### PR DESCRIPTION
I got interested in this because of #424 -- without F# 5, Expecto can't test any
assemblies that use F# 5 string interpolation. Since I opened that issue, F# 6
has come out. Might as well use that!

My only concern here is testing. Running the test suite, I see two reported failures, both having to do with the performance of SHA256 vs MD5. However, both of those tests also fail locally on main for me, so I don't think it's related to this change. 

Thanks for the lovely testing library!

Closes #424