### PR TITLE
Add obsolete attribute on deprecated functions

### DIFF
--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -537,6 +537,7 @@ module Tests =
   /// Runs tests with the supplied config.
   /// Returns 0 if all tests passed, otherwise 1
   /// Deprecated: please use runTestsWithCLIArgsAndCancel.
+  [<Obsolete("Deprecated: please use runTestsWithCLIArgsAndCancel")>]
   let runTestsWithCancel (ct:CancellationToken) config (tests:Test) =
     ANSIOutputWriter.setColourLevel config.colour
     Global.initialiseIfDefault
@@ -565,14 +566,18 @@ module Tests =
         |> Async.RunSynchronously
         ANSIOutputWriter.close()
         1
+
   /// Runs tests with the supplied config.
   /// Returns 0 if all tests passed, otherwise 1
   /// Deprecated: please use runTestsWithCLIArgs.
+  [<Obsolete("Deprecated: please use runTestsWithCLIArgs")>]
   let runTests config tests =
     runTestsWithCancel CancellationToken.None config tests
 
   /// Runs all given tests with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
+  /// Deprecated: please use runTestsWithCLIArgsAndCancel
+  [<Obsolete("Deprecated: please use runTestsWithCLIArgsAndCancel")>]
   let runTestsWithArgsAndCancel (ct:CancellationToken) config args tests =
     match ExpectoConfig.fillFromArgs config args with
     | ArgsUsage (usage, errors) ->
@@ -599,7 +604,8 @@ module Tests =
 
   /// Runs all given tests with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
-  /// Deprecated: please use runTestsWithCLIArgs.
+  /// Deprecated: please use runTestsWithCLIArgs
+  [<Obsolete("Deprecated: please use runTestsWithCLIArgs")>]
   let runTestsWithArgs config args tests =
     runTestsWithArgsAndCancel CancellationToken.None config args tests
 
@@ -611,6 +617,7 @@ module Tests =
   /// Runs tests in this assembly with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
   /// Deprecated: please use runTestsInAssemblyWithCLIArgsAndCancel
+  [<Obsolete("Deprecated: please use runTestsInAssemblyWithCLIArgsAndCancel")>]
   let runTestsInAssemblyWithCancel (ct:CancellationToken) config args =
     let config = { config with locate = getLocation (Assembly.GetEntryAssembly()) }
     testFromThisAssembly ()
@@ -629,6 +636,7 @@ module Tests =
   /// Runs tests in this assembly with the supplied command-line options.
   /// Returns 0 if all tests passed, otherwise 1
   /// Deprecated: please use runTestsInAssemblyWithCLIArgs
+  [<Obsolete("Deprecated: please use runTestsInAssemblyWithCLIArgs")>]
   let runTestsInAssembly config args =
     runTestsInAssemblyWithCancel CancellationToken.None config args
 

--- a/README.md
+++ b/README.md
@@ -49,15 +49,9 @@ What follows is the Table of Contents for this README, which also serves as the 
 - [.Net support](#net-support)
 - [Testing "Hello world"](#testing-hello-world)
 - [Running tests](#running-tests)
-  - [`runTests`](#runtests)
-  - [`runTestsWithArgs`](#runtestswithargs)
   - [`runTestsWithCLIArgs`](#runtestswithcliargs)
-  - [`runTestsWithCancel`](#runtestswithcancel)
-  - [`runTestsWithArgsAndCancel`](#runtestswithargsandcancel)
   - [`runTestsWithCLIArgsAndCancel`](#runtestswithcliargsandcancel)
-  - [`runTestsInAssembly`](#runtestsinassembly)
   - [`runTestsInAssemblyWithCLIArgs`](#runtestsinassemblywithcliargs)
-  - [`runTestsInAssemblyWithCancel`](#runtestsinassemblywithcancel)
   - [`runTestsInAssemblyWithCLIArgsAndCancel`](#runtestsinassemblywithcliargsandcancel)
   - [Filtering with `filter`](#filtering-with-filter)
   - [Shuffling with `shuffle`](#shuffling-with-shuffle)
@@ -233,55 +227,20 @@ testCase "A simple test" (fun () ->
   Expect.equal 4 (2+2) "2+2 should equal 4")
 ```
 
-### `runTests`
-
-Signature `ExpectoConfig -> Test -> int`. Runs the passed tests with the passed
-configuration record. Note: now deprecated please use CLIArgs below.
-
-### `runTestsWithArgs`
-
-Signature `ExpectoConfig -> string[] -> Test -> int`. Runs the passed tests
-and also overrides the passed `ExpectoConfig` with the command line parameters.
-Note: now deprecated please use CLIArgs below.
-
 ### `runTestsWithCLIArgs`
 
 Signature `CLIArguments seq -> string[] -> Test -> int`. Runs the passed tests
 and also overrides the passed `CLIArguments` with the command line parameters.
-
-### `runTestsWithCancel`
-
-Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests with the passed
-configuration record. Note: now deprecated please use CLIArgs below.
-
-### `runTestsWithArgsAndCancel`
-
-Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests
-and also overrides the passed `ExpectoConfig` with the command line parameters.
-configuration record. Note: now deprecated please use CLIArgs below.
 
 ### `runTestsWithCLIArgsAndCancel`
 
 Signature `CancellationToken -> ExpectoConfig -> Test -> int`. Runs the passed tests
 and also overrides the passed `CLIArguments` with the command line parameters.
 
-### `runTestsInAssembly`
-
-Signature `ExpectoConfig -> string[] -> int`. Runs the tests in the current
-assembly and also overrides the passed `ExpectoConfig` with the command line
-parameters. All tests need to be marked with the `[<Tests>]` attribute.
-Note: now deprecated please use CLIArgs below.
-
 ### `runTestsInAssemblyWithCLIArgs`
 
 Signature `CLIArguments seq -> string[] -> int`. Runs the tests in the current
 assembly and also overrides the passed `CLIArguments` with the command line
-parameters. All tests need to be marked with the `[<Tests>]` attribute.
-
-### `runTestsInAssemblyWithCancel`
-
-Signature `CancellationToken -> ExpectoConfig -> string[] -> int`. Runs the tests in the current
-assembly and also overrides the passed `ExpectoConfig` with the command line
 parameters. All tests need to be marked with the `[<Tests>]` attribute.
 
 ### `runTestsInAssemblyWithCLIArgsAndCancel`


### PR DESCRIPTION
This PR introduces Obsolete attributes on deprecated functions. Ref: #429 

Also, we could perhaps remove them altogether on a future major release. What do you think?