### PR TITLE
Loosen FSharp.Core version requirement

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,7 +3,7 @@ framework netstandard2.1, net6.0
 storage none
 version 7.1.5
 
-nuget FSharp.Core ~6
+nuget FSharp.Core ~> 7
 nuget FsCheck ~> 2.14
 nuget Hopac ~> 0.4
 nuget DiffPlex ~> 1.5

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,7 +3,7 @@ framework netstandard2.1, net6.0
 storage none
 version 7.1.5
 
-nuget FSharp.Core ~> 7
+nuget FSharp.Core >= 6
 nuget FsCheck ~> 2.14
 nuget Hopac ~> 0.4
 nuget DiffPlex ~> 1.5


### PR DESCRIPTION
quick PR to change expecto's `FSharp.Core` version requirement from `(= 7.0.200)` to ` (>= 7.0.200 && < 8.0.0)`

closes #458 