### PR TITLE
Loosen FSharp.Core version constraint

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -32,9 +32,9 @@ group Build
   nuget Fake.IO.Zip
   nuget Fake.Tools.Git
   nuget Fake.Tools.Octo
-  nuget Microsoft.Build 17.3.2
-  nuget Microsoft.Build.Framework 17.3.2
-  nuget Microsoft.Build.Tasks.Core 17.3.2
-  nuget Microsoft.Build.Utilities.Core 17.3.2
+  nuget Microsoft.Build 17.6.3
+  nuget Microsoft.Build.Framework 17.6.3
+  nuget Microsoft.Build.Tasks.Core 17.6.3
+  nuget Microsoft.Build.Utilities.Core 17.6.3
   nuget Nuget.Protocol
   nuget nosln

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -3,7 +3,7 @@ framework netstandard2.1, net6.0
 storage none
 version 7.1.5
 
-nuget FSharp.Core ~6
+nuget FSharp.Core >= 6
 nuget FsCheck ~> 2.14
 nuget Hopac ~> 0.4
 nuget DiffPlex ~> 1.5


### PR DESCRIPTION
In response to #459 and #458. Seeing if different versioning approach avoids the insecure package issue