### PR TITLE
Update FsCheck3 support to release as a pre-release version of Expecto.FsCheck

### DIFF
--- a/Expecto.FsCheck3/Expecto.FsCheck3.fsproj
+++ b/Expecto.FsCheck3/Expecto.FsCheck3.fsproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Expecto.FsCheck3</PackageId>
+    <PackageId>Expecto.FsCheck</PackageId>
     <Description>Property testing for Expecto, powered by FsCheck3</Description>
+    <VersionSuffix>fscheck3</VersionSuffix>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,7 +13,7 @@ nuget BenchmarkDotNet ~> 0.13.5
 group FsCheck3
   source https://api.nuget.org/v3/index.json
 
-  nuget FsCheck ~> 3.0.0-beta2
+  nuget FsCheck ~> 3
 
 group Build
   source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This way we don't have to create a separate package. Should simplify adoption and trimming once FsCheck 3 reaches general release.

#450 