### PR TITLE
Fix paket install (FsCheck3 versioning)

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -13,7 +13,7 @@ nuget BenchmarkDotNet ~> 0.13.5
 group FsCheck3
   source https://api.nuget.org/v3/index.json
 
-  nuget FsCheck ~> 3
+  nuget FsCheck >= 3 prerelease
 
 group Build
   source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Replace #464. I updated recommended packaged, but whitebolt kept saying the new commit didn't warrant a rescan.