### PR TITLE
Fix pack build task

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,10 @@
-### 10.1.0 - 2023-06-08
-* Add Theory Test Support #456
+### 10.1.0 - 2023-06-26
+* Add Theory Test Support #456, thanks @ratsclub
+* Loosen the FSharp.Core version requirement #458, thanks @farlee2121 and @JohnTheGr8
+* New Expecto.FsCheck pre-release version with FsCheck3 support #450, thanks @farlee2121
+* Add `Flip.Expect.hasLength` #455, thanks @JohnTheGr8
 
 #### 10.0.0 - 2023-04-20
-* New Expecto package with FsCheck3 support #450
 * Make Expect.isNotEmpty accept whitespace strings #452
 * Removed deprecated code #449
 * Bumped minimum framework to .NET 6 #447

--- a/build.fsx
+++ b/build.fsx
@@ -122,7 +122,7 @@ Target.create "Pack" <| fun _ ->
         ]
     }
 
-  let pkgSln = NoSln.WriteSolutionFile(files=libProjects, useTempSolutionFile=true)
+  let pkgSln = NoSln.WriteSolutionFile(projects=libProjects, useTempSolutionFile=true)
   let setParams (p: DotNet.PackOptions) =
     { p with
         OutputPath = Some pkgPath

--- a/build.fsx
+++ b/build.fsx
@@ -117,7 +117,7 @@ Target.create "Pack" <| fun _ ->
         NoLogo = true
         DoRestore = false
         Properties = [
-          "Version", release.NugetVersion
+          "VersionPrefix", release.NugetVersion
           "PackageReleaseNotes", String.toLines release.Notes
         ]
     }


### PR DESCRIPTION
 `dotnet fake build -t pack` wasn't creating packages. Appears to be caused by a change in how temporary solution files work.

Also added support for packing the FsCheck3 pre-release version of `Expecto.FsCheck` and release notes for the changes to be released