### PR TITLE
Improve support for interactive experiences

### DIFF
--- a/Expecto.Tests/Bug_RepeatedColourSetting.fs
+++ b/Expecto.Tests/Bug_RepeatedColourSetting.fs
@@ -1,0 +1,14 @@
+module Bug_RepeatedColourSetting
+
+open Expecto
+open Expecto.Logging
+
+
+[<Tests>]
+let tests =
+  ftest "Colour can be set repeatedly" {
+    let colours = [|Colour0; Colour256|]
+    colours |> Array.iter ANSIOutputWriter.setColourLevel
+    
+    Expect.equal (ANSIOutputWriter.getColour ()) (Array.last colours) "Colour should be the last set value"
+  }

--- a/Expecto.Tests/Expecto.Tests.fsproj
+++ b/Expecto.Tests/Expecto.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="FsCheckTests.fs" />
     <Compile Include="PerformanceTests.fs" />
     <Compile Include="Bug341.fs" />
+    <Compile Include="Bug_RepeatedColourSetting.fs" />
     <Compile Include="Main.fs" />
     <None Include="paket.references" />
     <ProjectReference Include="..\Expecto.Hopac\Expecto.Hopac.fsproj" />

--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -520,6 +520,9 @@ module Impl =
       colour: ColourLevel
       /// Split test names by `.` or `/`
       joinWith: JoinWith
+      /// A factory method taking the configured min log level and returning a logging config.
+      /// Can be used to swap out log targets like the LiterateConsoleTarget, TextWriterTarget, and OutputWindowTarget
+      loggingConfigFactory: (LogLevel -> LoggingConfig) option
     }
     static member defaultConfig =
       { runInParallel = true
@@ -546,6 +549,7 @@ module Impl =
         noSpinner = false
         colour = Colour8
         joinWith = JoinWith.Dot
+        loggingConfigFactory = None
       }
 
     member x.appendSummaryHandler handleSummary =

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -644,6 +644,9 @@ module Tests =
   let runTestsInAssemblyWithCLIArgs cliArgs args =
     runTestsInAssemblyWithCLIArgsAndCancel CancellationToken.None cliArgs args
 
+  /// Runs all given tests with the supplied typed command-line options.
+  /// Returns the console output as a string (with ANSI coloring by default)
+  /// Useful for interactive environments like F# interactive or notebooks
   let runTestsReturnLogs cliArgs args tests =
     let tryBuildConfig cliArgs args =
         let config =

--- a/Expecto/Logging.fs
+++ b/Expecto/Logging.fs
@@ -879,7 +879,7 @@ module internal ANSIOutputWriter =
     override __.WriteLine() = write "\n"
 
   let mutable internal colours = None
-  let internal setColourLevel c = if colours.IsNone then colours <- Some c
+  let internal setColourLevel c = colours <- Some c
   let internal getColour() = Option.defaultValue Colour8 colours
 
   let colourReset = "\u001b[0m"

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ runTestsWithCLIArgs [] [||] simpleTest
 which returns 1 if any tests failed, otherwise 0. Useful for returning to the
 operating system as error code.
 
+For interactive environments, you can alternatively call [`runTestsReturnLogs`](#runtestsreturnlogs), which returns the console output as a string.
+
 It's worth noting that `<|` is just a way to change the associativity of the
 language parser. In other words; it's equivalent to:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ What follows is the Table of Contents for this README, which also serves as the 
   - [`runTestsWithCLIArgsAndCancel`](#runtestswithcliargsandcancel)
   - [`runTestsInAssemblyWithCLIArgs`](#runtestsinassemblywithcliargs)
   - [`runTestsInAssemblyWithCLIArgsAndCancel`](#runtestsinassemblywithcliargsandcancel)
+  - [`runTestsReturnLogs`](#runtestsreturnlogs)
   - [Filtering with `filter`](#filtering-with-filter)
   - [Shuffling with `shuffle`](#shuffling-with-shuffle)
   - [Stress testing](#stress-testing)
@@ -249,6 +250,22 @@ parameters. All tests need to be marked with the `[<Tests>]` attribute.
 Signature `CancellationToken -> CLIArguments seq -> string[] -> int`. Runs the tests in the current
 assembly and also overrides the passed `CLIArguments` with the command line
 parameters. All tests need to be marked with the `[<Tests>]` attribute.
+
+### `runTestsReturnLogs`
+
+Signature `CLIArguments seq -> string[] -> Test -> string`.
+Accepts the same arguments as `runTestsWithCLIArgs`, but returns the console output as a string.
+
+This is useful for interactive environments like [F# interactive](https://learn.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/) and [Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode), where console output is not available but the returned string can be displayed instead.
+
+Note that ANSI colors are used by default, but can be turned off using `--colours 0`.
+```fsharp
+runTestsReturnLogs [] [|"--colours";"0"|] tests
+```
+
+Any valid CLI arguments work, including `--help` and `--list-tests`.
+
+
 
 ### Filtering with `filter`
 

--- a/build.fsx
+++ b/build.fsx
@@ -169,17 +169,17 @@ Target.create "Release" (fun _ ->
 
 Target.create "All" ignore
 
-// "CheckEnv"
-//   ==> "Release"
+"CheckEnv"
+  ==> "Release"
 
-// "Clean"
-//   ==> "BuildExpecto"
-//   ==> "BuildBenchmarkDotNet"
-//   ==> "BuildTest"
-//   ==> "RunTest"
-//   ==> "Pack"
-//   ==> "All"
-//   ==> "Push"
-//   ==> "Release"
+"Clean"
+  ==> "BuildExpecto"
+  ==> "BuildBenchmarkDotNet"
+  ==> "BuildTest"
+  ==> "RunTest"
+  ==> "Pack"
+  ==> "All"
+  ==> "Push"
+  ==> "Release"
 
 Target.runOrDefaultWithArguments "All"


### PR DESCRIPTION
## Motivation
Expecto is uniquely suitable for interactive environments (like FSI or Polyglot Notebooks) because it treats tests as values. Tests can be defined and executed all in the same code.

However, none of the current runTests methods print output to interactive environments like FSI.

## If this PR is merged
This PR adds a new method that collects logs from the test run then returns them as a string.
This allows easily displaying test output in interactive environments.

For example, here's a polyglot notebook using `runTestsWithCLIArgs`

![image](https://github.com/haf/expecto/assets/2847259/b5caf323-a7f0-47f9-b400-d1cc141d4161)

Here's the same interactive cell using `runTestsReturnLogs`
![image](https://github.com/haf/expecto/assets/2847259/6c882add-0c19-4148-ba2a-44621fcb7b6e)

The new `runTestsReturnLogs` should obey options the same as other run methods
![image](https://github.com/haf/expecto/assets/2847259/9623e82c-31ed-4ebb-a2e8-6da85da5e495)
