### PR TITLE
Add *testCaseTask functions

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -1396,6 +1396,20 @@ let taskTests =
         fun ms -> task { return ms.CanWrite ==? true }
     ]
 
+    testCaseTask "simple" <| task {
+      Expect.equal 1 1 "1=1"
+    }
+
+    testCaseTask "let" <| task {
+      let! n = async { return 1 }
+      Expect.equal n 1 "n=1"
+    }
+
+    testCaseTask "can fail" <| task {
+      let! n = async { return 2 }
+      Expect.equal n 1 "n=1"
+    } |> assertTestFails
+
     testTask "simple" {
       do! Task.Delay 1
       Expect.equal 1 1 "1=1"

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -2,7 +2,6 @@ namespace Expecto
 
 #nowarn "46"
 open System
-open System.Reflection
 open System.Threading
 open System.Threading.Tasks
 
@@ -88,18 +87,24 @@ module Tests =
   let inline testCaseWithCancel name test = TestLabel(name, TestCase (SyncWithCancel test,Normal), Normal)
   /// Builds an async test case
   let inline testCaseAsync name test = TestLabel(name, TestCase (Async test,Normal), Normal)
+  /// Builds an async test case from a task
+  let inline testCaseTask name test = TestLabel(name, TestCase (Async test,Normal), Normal)
   /// Builds a test case that will make Expecto to ignore other unfocused tests
   let inline ftestCase name test = TestLabel(name, TestCase (Sync test, Focused), Focused)
   /// Builds a test case with cancel that will make Expecto to ignore other unfocused tests
   let inline ftestCaseWithCancel name test = TestLabel(name, TestCase (SyncWithCancel test, Focused), Focused)
   /// Builds an async test case that will make Expecto to ignore other unfocused tests
   let inline ftestCaseAsync name test = TestLabel(name, TestCase (Async test, Focused), Focused)
+  /// Builds an async test case from a task, that will make Expecto to ignore other unfocused tests
+  let inline ftestCaseTask name test = TestLabel(name, TestCase (Async test, Focused), Focused)
   /// Builds a test case that will be ignored by Expecto
   let inline ptestCase name test = TestLabel(name, TestCase (Sync test, Pending), Pending)
   /// Builds a test case with cancel that will be ignored by Expecto
   let inline ptestCaseWithCancel name test = TestLabel(name, TestCase (SyncWithCancel test, Pending), Pending)
   /// Builds an async test case that will be ignored by Expecto
   let inline ptestCaseAsync name test = TestLabel(name, TestCase (Async test, Pending), Pending)
+  /// Builds an async test case from a task, that will be ignored by Expecto
+  let inline ptestCaseTask name test = TestLabel(name, TestCase (Async test, Pending), Pending)
   /// Test case or list needs to run sequenced. Use for any benchmark code or
   /// for tests using `Expect.isFasterThan`
   let inline testSequenced test = Sequenced (Synchronous,test)
@@ -234,9 +239,9 @@ module Tests =
           do! task.Run f |> Async.AwaitTask
       }
       match focusState with
-      | Normal -> testCaseAsync name a
-      | Focused -> ftestCaseAsync name a
-      | Pending -> ptestCaseAsync name a
+      | Normal -> testCaseTask name a
+      | Focused -> ftestCaseTask name a
+      | Pending -> ptestCaseTask name a
 
   /// Builds a task test case
   let inline testTask name =

--- a/Expecto/Model.fs
+++ b/Expecto/Model.fs
@@ -2,6 +2,7 @@ namespace Expecto
 
 open System
 open System.Threading
+open System.Threading.Tasks
 
 type SourceLocation =
   { sourcePath: string; lineNumber: int }

--- a/Expecto/Test.fs
+++ b/Expecto/Test.fs
@@ -141,4 +141,3 @@ module Test =
     | Async test -> timeoutAsync test |> Async
     | AsyncFsCheck (testConfig, stressConfig, test) ->
       AsyncFsCheck (testConfig, stressConfig, test >> timeoutAsync)
-

--- a/README.md
+++ b/README.md
@@ -292,12 +292,12 @@ The default config will run FsCheck tests with a higher end size than normal.
 
 Expecto supports the following test constructors:
 
-- normal test cases with `testCase` and `testCaseAsync`
+- normal test cases with `testCase`, `testCaseAsync` and `testCaseTask`
 - lists of tests with `testList`
 - test fixtures with `testFixture`, `testFixtureAsync`, `testFixtureTask`
-- pending tests (that aren't run) with `ptestCase` and `ptestCaseAsync`
-- focused tests (that are the only ones run) with `ftestCase` and
-   `ftestCaseAsync`
+- pending tests (that aren't run) with `ptestCase`, `ptestCaseAsync` and `ptestCaseTask`
+- focused tests (that are the only ones run) with `ftestCase`,
+   `ftestCaseAsync` and `ftestCaseTask`
 - sequenced tests with `testSequenced` and `testSequencedGroup` (tests inside a
    group are run in sequence w.r.t each other)
 - parametised tests with `testParam`
@@ -325,6 +325,7 @@ test project.**
 - `testTask : string -> TestTaskBuilder` - Builds a task test case in a computation expression.
 - `testCase : string -> (unit -> unit) -> Test` - Builds a test case from a test function.
 - `testCaseAsync : string -> Async<unit> -> Test` - Builds an async test case from an async expression.
+- `testCaseTask : string -> Task<unit> -> Test` - Builds an async test case from a task expression.
 
 ### `testList` for grouping
 
@@ -462,6 +463,7 @@ testList "theory testing with an expected result" [
 - `ptestAsync`
 - `ptestTask`
 - `ptestCaseAsync`
+- `ptestCaseTask`
 - `ptestTheory`
 - `ptestTheoryAsync`
 - `ptestTheoryTask`
@@ -507,6 +509,7 @@ Focusing can be done with
 - `ftestCase`
 - `ftestList`
 - `ftestCaseAsync`
+- `ftestCaseTask`
 - `ftest`
 - `ftestAsync`
 - `ftestTask`


### PR DESCRIPTION
This PR introduces the missing `*testCaseTask` functions.

For context, I wanted to remove code similar to this from the codebases I work with: https://github.com/demystifyfp/FsToolkit.ErrorHandling/blob/a0fa8595acd4c4581e8e0cb8586e45c7a7f5a47b/tests/FsToolkit.ErrorHandling.TaskResult.Tests