### PR TITLE
Fix testCaseTask to accept a task, not an Async

### DIFF
--- a/Expecto.Tests/PerformanceTests.fs
+++ b/Expecto.Tests/PerformanceTests.fs
@@ -24,24 +24,7 @@ let performance =
     testCase "md5 equals sha256" (fun _ ->
       Expect.isFasterThan runMD5 runSHA256 "MD5 equals SHA256 should fail"
     ) |> assertTestFailsWithMsgContaining "same"
-
-    testCase "sha256 versus md5" (fun _ ->
-      if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
-        skiptest "Doesn't hold true on this platform for unclear reasons"
-      Expect.isFasterThan
-        (runSHA256 >> ignore |> repeat10)
-        (runMD5 >> ignore |> repeat10)
-        "SHA256 is faster than MD5 should fail"
-    ) |> assertTestFailsWithMsgContaining "slower"
-
-    testCase "md5 versus sha256" <| fun _ ->
-      if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
-        skiptest "Doesn't hold true on this platform for unclear reasons"
-      Expect.isFasterThan
-        (runMD5 >> ignore |> repeat10)
-        (runSHA256 >> ignore |> repeat10)
-        "MD5 is faster than SHA256"
-    ]
+  ]
 
 [<Tests>]
 let findFastest =

--- a/Expecto.Tests/PerformanceTests.fs
+++ b/Expecto.Tests/PerformanceTests.fs
@@ -16,6 +16,7 @@ let runMD5() = md5.ComputeHash data
 let runSHA256() = sha256.ComputeHash data
 
 
+open System.Runtime.InteropServices;
 [<Tests>]
 let performance =
   testSequenced <| testList "performance cryptography tests" [
@@ -25,6 +26,8 @@ let performance =
     ) |> assertTestFailsWithMsgContaining "same"
 
     testCase "sha256 versus md5" (fun _ ->
+      if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
+        skiptest "Doesn't hold true on this platform for unclear reasons"
       Expect.isFasterThan
         (runSHA256 >> ignore |> repeat10)
         (runMD5 >> ignore |> repeat10)
@@ -32,6 +35,8 @@ let performance =
     ) |> assertTestFailsWithMsgContaining "slower"
 
     testCase "md5 versus sha256" <| fun _ ->
+      if RuntimeInformation.IsOSPlatform(OSPlatform.Linux) then
+        skiptest "Doesn't hold true on this platform for unclear reasons"
       Expect.isFasterThan
         (runMD5 >> ignore |> repeat10)
         (runSHA256 >> ignore |> repeat10)

--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -1396,57 +1396,61 @@ let taskTests =
         fun ms -> task { return ms.CanWrite ==? true }
     ]
 
-    testCaseTask "simple" <| task {
-      Expect.equal 1 1 "1=1"
-    }
+    testList "testCaseTask" [
+      testCaseTask "simple" <| task {
+        Expect.equal 1 1 "1=1"
+      }
 
-    testCaseTask "let" <| task {
-      let! n = async { return 1 }
-      Expect.equal n 1 "n=1"
-    }
-
-    testCaseTask "can fail" <| task {
-      let! n = async { return 2 }
-      Expect.equal n 1 "n=1"
-    } |> assertTestFails
-
-    testTask "simple" {
-      do! Task.Delay 1
-      Expect.equal 1 1 "1=1"
-    }
-
-    testTask "let" {
-      let! n = Task.FromResult 23
-      Expect.equal n 23 "n=23"
-    }
-
-    testTask "can fail" {
-        let! n = Task.FromResult 2
+      testCaseTask "let" <| task {
+        let! n = async { return 1 }
         Expect.equal n 1 "n=1"
-    } |> assertTestFails
+      }
 
-    testTask "two" {
-        let! n = Task.FromResult 2
-        let! m = Task.FromResult (3*n)
-        Expect.equal m 6 "m=6"
-    }
+      testCaseTask "can fail" <| task {
+        let! n = async { return 2 }
+        Expect.equal n 1 "n=1"
+      } |> assertTestFails
+    ]
 
-    testTask "two can fail" {
-        let! n = Task.FromResult 2
-        let! m = Task.FromResult (3*n)
-        Expect.equal m 7 "m=7"
-    } |> assertTestFails
+    testList "testTask" [
+      testTask "simple" {
+        do! Task.Delay 1
+        Expect.equal 1 1 "1=1"
+      }
 
-    testTask "two can fail middle" {
-        let! n = Task.FromResult 2
-        Expect.equal n 3 "n=3"
-        let! m = Task.FromResult (3*n)
-        Expect.equal m 6 "m=6"
-    } |> assertTestFails
+      testTask "let" {
+        let! n = Task.FromResult 23
+        Expect.equal n 23 "n=23"
+      }
 
-    testTask "inner skip" {
-      skiptest "skipped"
-    }
+      testTask "can fail" {
+          let! n = Task.FromResult 2
+          Expect.equal n 1 "n=1"
+      } |> assertTestFails
+
+      testTask "two" {
+          let! n = Task.FromResult 2
+          let! m = Task.FromResult (3*n)
+          Expect.equal m 6 "m=6"
+      }
+
+      testTask "two can fail" {
+          let! n = Task.FromResult 2
+          let! m = Task.FromResult (3*n)
+          Expect.equal m 7 "m=7"
+      } |> assertTestFails
+
+      testTask "two can fail middle" {
+          let! n = Task.FromResult 2
+          Expect.equal n 3 "n=3"
+          let! m = Task.FromResult (3*n)
+          Expect.equal m 6 "m=6"
+      } |> assertTestFails
+
+      testTask "inner skip" {
+        skiptest "skipped"
+      }
+    ]
   ]
 
 [<Tests>]

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -88,7 +88,7 @@ module Tests =
   /// Builds an async test case
   let inline testCaseAsync name test = TestLabel(name, TestCase (Async test,Normal), Normal)
   /// Builds an async test case from a task
-  let inline testCaseTask name test = TestLabel(name, TestCase (Async test,Normal), Normal)
+  let inline testCaseTask name test = TestLabel(name, TestCase (Async (Async.AwaitTask test),Normal), Normal)
   /// Builds a test case that will make Expecto to ignore other unfocused tests
   let inline ftestCase name test = TestLabel(name, TestCase (Sync test, Focused), Focused)
   /// Builds a test case with cancel that will make Expecto to ignore other unfocused tests
@@ -96,7 +96,7 @@ module Tests =
   /// Builds an async test case that will make Expecto to ignore other unfocused tests
   let inline ftestCaseAsync name test = TestLabel(name, TestCase (Async test, Focused), Focused)
   /// Builds an async test case from a task, that will make Expecto to ignore other unfocused tests
-  let inline ftestCaseTask name test = TestLabel(name, TestCase (Async test, Focused), Focused)
+  let inline ftestCaseTask name test = TestLabel(name, TestCase (Async (Async.AwaitTask test), Focused), Focused)
   /// Builds a test case that will be ignored by Expecto
   let inline ptestCase name test = TestLabel(name, TestCase (Sync test, Pending), Pending)
   /// Builds a test case with cancel that will be ignored by Expecto
@@ -104,7 +104,7 @@ module Tests =
   /// Builds an async test case that will be ignored by Expecto
   let inline ptestCaseAsync name test = TestLabel(name, TestCase (Async test, Pending), Pending)
   /// Builds an async test case from a task, that will be ignored by Expecto
-  let inline ptestCaseTask name test = TestLabel(name, TestCase (Async test, Pending), Pending)
+  let inline ptestCaseTask name test = TestLabel(name, TestCase (Async (Async.AwaitTask test), Pending), Pending)
   /// Test case or list needs to run sequenced. Use for any benchmark code or
   /// for tests using `Expect.isFasterThan`
   let inline testSequenced test = Sequenced (Synchronous,test)
@@ -235,8 +235,8 @@ module Tests =
     member inline __.TryFinally(p, cf) = task.TryFinally(p, cf)
     member inline __.TryWith(p, cf) = task.TryWith(p, cf)
     member __.Run f =
-      let a = async {
-          do! task.Run f |> Async.AwaitTask
+      let a = task {
+          do! task.Run f
       }
       match focusState with
       | Normal -> testCaseTask name a

--- a/build.fsx
+++ b/build.fsx
@@ -169,17 +169,17 @@ Target.create "Release" (fun _ ->
 
 Target.create "All" ignore
 
-// "CheckEnv"
-//   ==> "Release"
+"CheckEnv"
+  ==> "Release"
 
-// "Clean"
-//   ==> "BuildExpecto"
-//   ==> "BuildBenchmarkDotNet"
-//   ==> "BuildTest"
-//   ==> "RunTest"
-//   ==> "Pack"
-//   ==> "All"
-//   ==> "Push"
-//   ==> "Release"
+"Clean"
+  ==> "BuildExpecto"
+  ==> "BuildBenchmarkDotNet"
+  ==> "BuildTest"
+  ==> "RunTest"
+  ==> "Pack"
+  ==> "All"
+  ==> "Push"
+  ==> "Release"
 
 Target.runOrDefaultWithArguments "All"


### PR DESCRIPTION
Fix testCaseTask to accept a task, not an Async. Also fix test name conflicts.

I noticed this was causing build troubles when I went back to the interactive PR, so I fixed it.