### PR TITLE
Support ValueTask and Async bindings in testTask

### DIFF
--- a/Expecto.Tests/Tests.fs
+++ b/Expecto.Tests/Tests.fs
@@ -1450,6 +1450,22 @@ let taskTests =
       testTask "inner skip" {
         skiptest "skipped"
       }
+      testTask "can let! bind ValueTask<T>" {
+        let expected = 5
+        let valueTask = ValueTask.FromResult(expected)
+        let! actual = valueTask
+        Expect.equal expected actual "should be able to let! bind ValueTask<T>"
+      }
+      testTask "can do! bind ValueTask" {
+        let valueTask = ValueTask.CompletedTask
+        do! valueTask
+      }
+      testTask "can let! bind Async<T>" {
+        let expected = 5
+        let asyncValue = async.Return(expected)
+        let! actual = asyncValue
+        Expect.equal expected actual "should be able to let! bind ValueTask<T>"
+      }
     ]
   ]
 

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -243,6 +243,13 @@ module Tests =
       | Focused -> ftestCaseTask name a
       | Pending -> ptestCaseTask name a
 
+  [<AutoOpen>]
+  module TestTaskExtensions =
+    type TestTaskBuilder with
+      member inline __.Bind(p1:ValueTask<'a>, p2:'a->_) = task.Bind(p1, p2)
+      member inline __.Bind(p1:ValueTask, p2:unit->_) = task.Bind(p1, p2)
+      member inline __.Bind(p1:Async<'a>, p2:'a->_) = task.Bind(p1, p2)
+
   /// Builds a task test case
   let inline testTask name =
     TestTaskBuilder (name, Normal)


### PR DESCRIPTION
Fixes #488 

Adds support for ValueTask<T>, ValueTask, and Async<T> bindings to the testTask expression.

This is accomplished through overloads of the Bind method.
I looked into inheriting the TaskBuilder, but it's constructor is hidden by the [tasks.fsi file](https://github.com/dotnet/fsharp/blob/9669913821972b3d278b76f8b0006ba194827140/src/FSharp.Core/tasks.fsi).