### PR TITLE
Replace a couple of sprintf calls in printVerses with interpolated st…

### DIFF
--- a/Expecto/Expect.fs
+++ b/Expecto/Expect.fs
@@ -61,8 +61,8 @@ let private printVerses (firstName:string) first (secondName:string) second =
     if  first.Length > 100 || second.Length > 100
      || Seq.exists ((=)'\n') first || Seq.exists ((=)'\n') second
     then '\n' else ' '
-  let first = sprintf "\n%s:%c%s" firstName prefix first
-  let second = sprintf "\n%s:%c%s" secondName prefix second
+  let first = $"\n%s{firstName}:%c{prefix}%s{first}"
+  let second = $"\n%s{secondName}:%c{prefix}%s{second}"
   let diffs = allDiffs first second
   String.Concat(highlightAllGreen diffs first, highlightAllRed diffs second)
 


### PR DESCRIPTION
…rings

refs #498 

I tried stubbing out the DVar/Logging bits that are described in #498 and then running the ```I am (should fail)``` example test from the Expecto project template in an AOT build, and it crashed with
```
[E] 2024-07-21T22:25:59.0322420+00:00: samples.I am (should fail) errored in 00:00:00 [Expecto]
 - errors: [System.NotSupportedException: 'Microsoft.FSharp.Core.PrintfImpl+Specializations`3[Microsoft.FSharp.Core.Unit,System.String,System.String].CaptureFinal2[System.Char,System.String](Microsoft.FSharp.Core.PrintfImpl+Step[])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x2f
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x189
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.buildCaptureFunc[a](PrintfImpl.FormatSpecifier, a, Type[], Type, Tuple`5) + 0x21b
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFuncFactoryAux(FSharpList`1, String, Type, Int32&) + 0x22c
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFuncFactoryAux(FSharpList`1, String, Type, Int32&) + 0x1ea
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.parseAndCreateFunctionFactory() + 0x78
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedPrinterFactory() + 0x1f
   at Microsoft.FSharp.Core.PrintfImpl.FormatParser`4.GetCurriedStringPrinter() + 0x20
   at Expecto.Expect.printVerses[a,b](String, a, String, b) + 0x197
   at Expecto.Expect.defaultDiffPrinter@404.Invoke(Object, Object) + 0x26
   at Expecto.Expect.equalWithDiffPrinter$cont@383[a](FSharpFunc`2, a, a, String, Object, Object, Unit) + 0x405
   at Expecto.Expect.equalWithDiffPrinter[a](FSharpFunc`2, a, a, String) + 0x71
   at Tests.f@1() + 0x32
   at Tests.tests@12-3.Invoke(ResumableStateMachine`1& sm) + 0xd
   at <StartupCode$FSharp-Core>.$Tasks.resumptionInfo@171.MoveNext(ResumableStateMachine`1&) + 0x37
--- End of stack trace from previous location ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() + 0x20
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task) + 0xb2
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task, ConfigureAwaitOptions) + 0x4b
   at Microsoft.FSharp.Control.TaskBuilderExtensions.HighPriority.cont@405-8.Invoke(ResumableStateMachine`1& sm) + 0x30
   at <StartupCode$FSharp-Core>.$Tasks.resumptionInfo@171.MoveNext(ResumableStateMachine`1&) + 0x37]
```

and replacing these two sprintfs with interpolated strings allows it to run, and print out a failure message.
This is basically the simplest possible test case, but it at least shows that it can execute tests and process the results in AOT builds.