### PR TITLE
Fix the build for Expecto.BenchmarkDotNet.Tests

### DIFF
--- a/Expecto.BenchmarkDotNet.Tests/BenchmarkDotNetTests.fs
+++ b/Expecto.BenchmarkDotNet.Tests/BenchmarkDotNetTests.fs
@@ -43,4 +43,4 @@ let tests =
 
 [<EntryPoint>]
 let main args =
-    runTestsInAssembly defaultConfig args
+    runTestsInAssemblyWithCLIArgs [] args

--- a/Expecto.BenchmarkDotNet.Tests/Expecto.BenchmarkDotNet.Tests.fsproj
+++ b/Expecto.BenchmarkDotNet.Tests/Expecto.BenchmarkDotNet.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BenchmarkDotNetTests.fs" />

--- a/build.fsx
+++ b/build.fsx
@@ -79,7 +79,7 @@ Target.create "BuildExpecto" (fun _ ->
 )
 
 Target.create "BuildBenchmarkDotNet" (fun _ ->
-  let sln = NoSln.WriteSolutionFile(files=benchmarkProjects, useTempSolutionFile=true)
+  let sln = NoSln.WriteSolutionFile(projects=benchmarkProjects, useTempSolutionFile=true)
   build sln
 )
 


### PR DESCRIPTION
I hadn't realised before, but it looks like the Expecto.BenchmarkDotNet.Tests test project isn't actually being built by the CI build - there are warnings in the build about not finding any projects to restore, e.g.

https://github.com/haf/expecto/actions/runs/10412005602/job/28836955136#step:4:355

And running it directly fails with an error about ```runTestsInAssembly``` not being found.

I don't know about the history of this project (maybe you don't actually want to run benchmarks during the CI  build?) - but it seems wrong to not at least compile it?