### PR TITLE
Update the Github checkout/setup dotnet actions to v4 in the CI builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .Net
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         global-json-file: "./global.json"
     - run: ./fake build --target Pack


### PR DESCRIPTION
I just noticed these 

![image](https://github.com/user-attachments/assets/a3c44e86-3d1a-4460-9137-22c9056decc5)

in the CI builds and thought it might be useful to update the action to the latest version.