### PR TITLE
A few fsharp-analyzers suggestions

### DIFF
--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -960,7 +960,7 @@ module Impl =
     else
       let nestedFunc =
         t.GetTypeInfo().GetFields()
-        |> Seq.tryFind (fun f -> isFsharpFuncType f.FieldType)
+        |> Array.tryFind (fun f -> isFsharpFuncType f.FieldType)
       match nestedFunc with
       | Some f -> f.GetValue(testFunc).GetType()
       | None -> t
@@ -969,7 +969,7 @@ module Impl =
     match testCode with
     | Sync test ->
       let t = getFuncTypeToUse test asm
-      let m = t.GetTypeInfo().GetMethods () |> Seq.find (fun m -> (m.Name = "Invoke") && (m.DeclaringType = t))
+      let m = t.GetTypeInfo().GetMethods () |> Array.find (fun m -> (m.Name = "Invoke") && (m.DeclaringType = t))
       (t.FullName, m.Name)
     | SyncWithCancel _ ->
       ("Unknown SyncWithCancel", "Unknown SyncWithCancel")

--- a/Expecto/Expecto.fs
+++ b/Expecto/Expecto.fs
@@ -543,7 +543,7 @@ module Tests =
       match Args.parseOptions options args with
       | Ok cliArguments ->
           let config =
-            Seq.fold (fun s a -> foldCLIArgumentToConfig a s) baseConfig cliArguments
+            List.fold (fun s a -> foldCLIArgumentToConfig a s) baseConfig cliArguments
           if List.exists(function List_Tests _ -> true | _ -> false) cliArguments then
             ArgsList config
           elif List.contains Version cliArguments then


### PR DESCRIPTION
I tried running the Expecto library code through a few fsharp-analyzers, and got a few suggested changes.
These ones are from https://g-research.github.io/fsharp-analyzers/analyzers/VirtualCallAnalyzer.html where it suggests replacing Seq functions with explicit types when the collection types are fixed:

```

Expecto.Impl.fs(963,11): Warning GRA-VIRTUALCALL-001 : Consider replacing the call of Seq.tryFind with a function from the Array module to avoid the costs of virtual calls.
Expecto.Impl.fs(972,47): Warning GRA-VIRTUALCALL-001 : Consider replacing the call of Seq.find with a function from the Array module to avoid the costs of virtual calls.
Expecto.fs(546,12): Warning GRA-VIRTUALCALL-001 : Consider replacing the call of Seq.fold with a function from the List module to avoid the costs of virtual calls.
```

Any thoughts?