### PR TITLE
Fix template installation command for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Expecto also provides a simple API for property based testing using FsCheck.
 
 ## Quickstart
 
-    dotnet new install Expecto.Template::*
+    dotnet new install "Expecto.Template::*"
     dotnet new expecto -n PROJECT_NAME -o FOLDER_NAME
     
 Follow [Smooth Testing](https://www.youtube.com/channel/UC2SN9CUu9LlOBukXXv_bT5Q) on YouTube to learn the basics.


### PR DESCRIPTION
## Summary

The installation command did not work for me in the fish shell on macOS. Adding the quotes fixed it.

I made the change using GitHub which unfortunately also applied some formatting or similar to an unrelated section.

## Fixes 

Before:
```
dotnet new install Expecto.Template::*
fish: No matches for wildcard 'Expecto.Template::*'. See `help wildcards-globbing`.
dotnet new install Expecto.Template::*
                   ^~~~~~~~~~~~~~~~~~^
```

After:
```
dotnet new install "Expecto.Template::*"
The following template packages will be installed:
   Expecto.Template::*
...
```


