### PR TITLE
Add builder methods for TestPrinters.

### DIFF
--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -222,6 +222,18 @@ module Impl =
       /// Prints a summary given the test result counts
       summary : ExpectoConfig -> TestRunSummary -> Async<unit> }
 
+    // NOTE: with* methods provide a compatibility layer allowing us to change the TestPrinters signature
+    //       without breaking YoloDev.Expecto.TestSdk and other dependent packages
+
+    static member withBeforeRun (beforeRun: (Test -> Async<unit>)) (printer: TestPrinters)= {printer with beforeRun = beforeRun}
+    static member withBeforeEach (beforeEach: (string -> Async<unit>)) (printer: TestPrinters) = {printer with beforeEach = beforeEach}
+    static member withInfo (info: (string -> Async<unit>)) (printer: TestPrinters) = {printer with info = info}
+    static member withPassed (passed: (string -> TimeSpan -> Async<unit>)) (printer: TestPrinters) = {printer with passed = passed}
+    static member withIgnored (ignored: (string -> string -> Async<unit>)) (printer: TestPrinters) = {printer with ignored = ignored}
+    static member withFailed (failed: (string -> string -> TimeSpan -> Async<unit>)) (printer: TestPrinters) = {printer with failed = failed}
+    static member withExn (exn: (string -> exn -> TimeSpan -> Async<unit>)) (printer: TestPrinters) = {printer with exn = exn}
+    static member withSummary (summary: (ExpectoConfig -> TestRunSummary -> Async<unit>)) (printer: TestPrinters) = {printer with summary = summary}
+
     static member printResult config (test:FlatTest) (result:TestSummary) =
       let name = config.joinWith.format test.name
       match result.result with

--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -225,7 +225,7 @@ module Impl =
     // NOTE: with* methods provide a compatibility layer allowing us to change the TestPrinters signature
     //       without breaking YoloDev.Expecto.TestSdk and other dependent packages
 
-    static member withBeforeRun (beforeRun: (Test -> Async<unit>)) (printer: TestPrinters)= {printer with beforeRun = beforeRun}
+    static member withBeforeRun (beforeRun: (Test -> Async<unit>)) (printer: TestPrinters) = {printer with beforeRun = beforeRun}
     static member withBeforeEach (beforeEach: (string -> Async<unit>)) (printer: TestPrinters) = {printer with beforeEach = beforeEach}
     static member withInfo (info: (string -> Async<unit>)) (printer: TestPrinters) = {printer with info = info}
     static member withPassed (passed: (string -> TimeSpan -> Async<unit>)) (printer: TestPrinters) = {printer with passed = passed}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 10.2.2 - 2025-02-28
+* Add builder methods for TestPrinters. Using builders allows TestPrinter signatures to evolve without breaking YoloDev.Expecto.TestSdk and other packages that need to build printers. This should reduce the need for version coordination between such packages, thanks @farlee2121
+
 ### 10.2.1 - 2024-03-15
 * Fix bug where testTask and testCaseTask allow the tasks to start immediately when the test is defined, breaking backward compatibility with testTask.
 


### PR DESCRIPTION
Using builders allows TestPrinter signatures to evolve without breaking YoloDev.Expecto.TestSdk and other packages that need to build printers. This should reduce the need for version coordination between such packages