### PR TITLE
Update github actions to fix deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup .Net
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: "./global.json"
     - run: ./fake build --target CI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup .Net
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: "./global.json"
       - run: ./fake build --target Release


### PR DESCRIPTION
I just saw these deprecation warnings in the CI builds and thought I'd try updating the actions to fix them:

<img width="1950" height="136" alt="image" src="https://github.com/user-attachments/assets/0db65741-a742-43db-9376-9d72c6207526" />
